### PR TITLE
[codex] Add taxonomy metadata automation foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,6 +238,7 @@ frontend/Litho/node_modules/
 frontend/Litho/build/
 frontend/Litho/.cursor/
 frontend/admin/.cursor/
+output/playwright/
 api/.cursor/
 
 # Database files

--- a/NEXT_STEPS_TAXONOMY_AUTOMATION.md
+++ b/NEXT_STEPS_TAXONOMY_AUTOMATION.md
@@ -1,0 +1,140 @@
+# Next Steps: Taxonomy And Automation
+
+Updated: April 6, 2026
+
+## Current State
+
+- Production taxonomy rename phase 1 has already been applied on `crafty-vps`.
+- The migration used was [f1c9e7a4b2d0_rename_taxonomy_subcategories_phase1.py](/home/wetende/Projects/craftyxhub/api/alembic/versions/f1c9e7a4b2d0_rename_taxonomy_subcategories_phase1.py).
+- The production database backup created before the rename is:
+  - `/root/craftyXhub/backups/taxonomy_pre_rename_20260406T093212Z.json`
+- Production Alembic head is now `f1c9e7a4b2d0`.
+- Published-post safety check after migration:
+  - `207` total posts
+  - `204` active posts
+  - `204` published active posts
+
+## What Was Renamed In Production
+
+- `Blockchain & Cryptocurrencies` -> `Blockchain & Crypto`
+- `Automation & Smart Tools` -> `Automation`
+- `Programming & Development` -> `Software Development`
+- `Cybersecurity Basics` -> `Cybersecurity & Privacy`
+- `Creator Economy & Monetization` -> `Creator Business`
+- `Online Business Strategies` -> `Online Business & Marketing`
+- `Career Development & Skills` -> `Career Growth & Job Search`
+- `Online Learning Platforms` -> `Learning & Skill Building`
+- `Productivity Hacks & Tools` -> `Productivity & Remote Work`
+- `Remote Work & Digital Nomad` -> `Freelancing`
+- `Personal Branding` -> `Personal Brand & Audience`
+- `Mental Health & Psychology` -> `Mental Health`
+- `Personal Growth & Self-Improvement` -> `Personal Growth`
+- `Minimalism & Intentional Living` -> `Intentional Living`
+- `Wellness & Work-Life Balance` -> `Work-Life Balance`
+
+## Tag Reassignment Already Done
+
+These tags were moved under `Productivity & Remote Work`:
+
+- `Remote Work`
+- `Work From Home`
+- `Digital Nomad`
+- `Async Work`
+- `Home Office`
+
+These tags were moved under `Freelancing`:
+
+- `Freelancing`
+- `Upwork`
+- `Fiverr`
+- `Consulting`
+- `Copywriting`
+- `UX Design`
+
+## Important Safety Notes
+
+- Category and subcategory names were changed in place.
+- Category IDs and tag IDs were preserved.
+- Category slugs were intentionally left unchanged.
+- This means published posts were not detached from their categories or tags.
+- Existing category URLs should still work because slugs did not change.
+
+## Slug Warning
+
+- Do not rename categories through the normal API update path unless the existing slug is passed explicitly.
+- In [post.py](/home/wetende/Projects/craftyxhub/api/services/post/post.py#L1469), `update_category()` regenerates a slug when the name changes and `slug` is omitted.
+- Future slug cleanup should happen only after redirect or legacy-slug support exists.
+
+## Local Repo State
+
+Local `main` is still dirty and should be parked before starting unrelated work.
+
+Current local WIP includes:
+
+- [ai.py](/home/wetende/Projects/craftyxhub/api/routers/v1/ai.py)
+- [ai.py](/home/wetende/Projects/craftyxhub/api/schemas/ai.py)
+- [__init__.py](/home/wetende/Projects/craftyxhub/api/services/ai/__init__.py)
+- [taxonomy.py](/home/wetende/Projects/craftyxhub/api/services/ai/taxonomy.py)
+- [post.py](/home/wetende/Projects/craftyxhub/api/services/post/post.py)
+- [test_ai_router.py](/home/wetende/Projects/craftyxhub/api/tests/test_ai_router.py)
+- [AiWriterPanel.jsx](/home/wetende/Projects/craftyxhub/frontend/src/components/ai-writer/AiWriterPanel.jsx)
+- [AdminPostEditor.jsx](/home/wetende/Projects/craftyxhub/frontend/src/views/dashboard/Posts/AdminPostEditor.jsx)
+- [f1c9e7a4b2d0_rename_taxonomy_subcategories_phase1.py](/home/wetende/Projects/craftyxhub/api/alembic/versions/f1c9e7a4b2d0_rename_taxonomy_subcategories_phase1.py)
+
+There are also unrelated local changes not touched during this work:
+
+- [postService.js](/home/wetende/Projects/craftyxhub/frontend/src/api/services/postService.js)
+- [index.jsx](/home/wetende/Projects/craftyxhub/frontend/src/views/dashboard/Posts/index.jsx)
+
+## Best Resume Order
+
+1. Create a branch for the current local WIP.
+2. Commit the taxonomy migration file so the repo matches production DB history.
+3. Decide whether to keep the AI taxonomy suggestion changes on the same branch or split them into a second branch.
+4. Avoid doing new unrelated work from dirty `main`.
+
+## Next Taxonomy Tasks
+
+1. Export the current post-rename taxonomy from production.
+2. Build the canonical tag plan around generalized concepts, not vendor names.
+3. Freeze slugs for now.
+4. Decide the final canonical tag list and the tags to merge or retire.
+5. Produce a full mapping sheet:
+   - `old_tag`
+   - `canonical_tag`
+   - `target_subcategory`
+   - `action`
+6. Identify which tags can be renamed in place.
+7. Identify which tags need merge migrations.
+8. Reassign `post_tags` rows before deleting duplicate tags.
+9. Re-check live tag usage counts after cleanup.
+10. Review and backfill the active posts that still have no tags.
+
+## Next Automation Tasks
+
+1. Finish the DB-driven taxonomy suggestion work already started locally.
+2. Make the backend read categories and tags from the database as the source of truth.
+3. Return taxonomy suggestions with category, subcategory, tag IDs, and confidence.
+4. Prefill those suggestions in the editor UI.
+5. Allow manual override in the UI.
+6. Add validation so selected tags belong to the correct taxonomy branch.
+7. Add low-confidence fallback behavior when classification is uncertain.
+8. Add publish-time validation for obviously mismatched taxonomy assignments.
+9. Add tests covering taxonomy suggestion quality and validation rules.
+
+## Good Follow-Up Work
+
+- Add an admin taxonomy management screen.
+- Add a report for unused tags and no-tag posts.
+- Add a safe tag-merge tool that updates `post_tags`.
+- Add redirect or legacy-slug support before any slug cleanup.
+- Add public tag pages only after the canonical tag set is stable.
+
+## Recommended Restart Point
+
+When work resumes, start here:
+
+1. Branch the current local WIP.
+2. Commit the migration so repo history matches production.
+3. Continue with the canonical tag mapping pass.
+4. After taxonomy cleanup is stable, continue the automation pipeline.

--- a/api/alembic/versions/3e1d8d5f4c21_add_taxonomy_lifecycle_slug_history_and_seo.py
+++ b/api/alembic/versions/3e1d8d5f4c21_add_taxonomy_lifecycle_slug_history_and_seo.py
@@ -1,0 +1,225 @@
+"""add taxonomy lifecycle slug history and seo
+
+Revision ID: 3e1d8d5f4c21
+Revises: f1c9e7a4b2d0
+Create Date: 2026-04-07 11:20:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "3e1d8d5f4c21"
+down_revision = "f1c9e7a4b2d0"
+branch_labels = None
+depends_on = None
+
+
+categories = sa.table(
+    "categories",
+    sa.column("id", sa.Integer()),
+    sa.column("name", sa.String(length=100)),
+    sa.column("slug", sa.String(length=100)),
+    sa.column("description", sa.Text()),
+    sa.column("parent_id", sa.Integer()),
+)
+
+
+def _fetch_category_id(connection, name: str, parent_id: int | None = None):
+    query = sa.select(categories.c.id).where(categories.c.name == name)
+    if parent_id is None:
+        query = query.where(categories.c.parent_id.is_(None))
+    else:
+        query = query.where(categories.c.parent_id == parent_id)
+    return connection.execute(query).scalar_one_or_none()
+
+
+def _ensure_category(
+    connection,
+    *,
+    parent_name: str,
+    name: str,
+    slug: str,
+    description: str | None = None,
+) -> None:
+    parent_id = _fetch_category_id(connection, parent_name, None)
+    if parent_id is None:
+        return
+
+    existing_id = _fetch_category_id(connection, name, parent_id)
+    if existing_id is not None:
+        return
+
+    connection.execute(
+        categories.insert().values(
+            name=name,
+            slug=slug,
+            description=description,
+            parent_id=parent_id,
+        )
+    )
+
+
+def _seed_slug_history(connection) -> None:
+    connection.execute(
+        sa.text(
+            """
+            INSERT INTO category_slug_history (category_id, slug)
+            SELECT c.id, c.slug
+            FROM categories c
+            WHERE c.slug IS NOT NULL
+              AND c.slug <> ''
+              AND NOT EXISTS (
+                SELECT 1
+                FROM category_slug_history h
+                WHERE h.slug = c.slug
+              )
+            """
+        )
+    )
+    connection.execute(
+        sa.text(
+            """
+            INSERT INTO tag_slug_history (tag_id, slug)
+            SELECT t.id, t.slug
+            FROM tags t
+            WHERE t.slug IS NOT NULL
+              AND t.slug <> ''
+              AND NOT EXISTS (
+                SELECT 1
+                FROM tag_slug_history h
+                WHERE h.slug = t.slug
+              )
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tags",
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.add_column(
+        "tags",
+        sa.Column("canonical_tag_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_tags_canonical_tag_id_tags",
+        "tags",
+        "tags",
+        ["canonical_tag_id"],
+        ["id"],
+    )
+
+    op.add_column("posts", sa.Column("seo_keywords", sa.JSON(), nullable=True))
+
+    op.create_table(
+        "category_slug_history",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("category_id", sa.Integer(), nullable=False),
+        sa.Column("slug", sa.String(length=100), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["category_id"], ["categories.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("slug"),
+    )
+    op.create_index(
+        "ix_category_slug_history_category_id",
+        "category_slug_history",
+        ["category_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_category_slug_history_slug",
+        "category_slug_history",
+        ["slug"],
+        unique=True,
+    )
+
+    op.create_table(
+        "tag_slug_history",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("tag_id", sa.Integer(), nullable=False),
+        sa.Column("slug", sa.String(length=50), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["tag_id"], ["tags.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("slug"),
+    )
+    op.create_index(
+        "ix_tag_slug_history_tag_id",
+        "tag_slug_history",
+        ["tag_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_tag_slug_history_slug",
+        "tag_slug_history",
+        ["slug"],
+        unique=True,
+    )
+
+    connection = op.get_bind()
+    _ensure_category(
+        connection,
+        parent_name="Tech & Innovation",
+        name="Products & Platforms",
+        slug="products-and-platforms",
+        description="Product previews, platform launches, reviews, and comparisons.",
+    )
+    _ensure_category(
+        connection,
+        parent_name="Business & Finance",
+        name="Business News & Market Intelligence",
+        slug="business-news-and-market-intelligence",
+        description="Business current-affairs, market signals, company risk, and valuation analysis.",
+    )
+    _seed_slug_history(connection)
+
+    op.alter_column("tags", "is_active", server_default=None)
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    tech_parent_id = _fetch_category_id(connection, "Tech & Innovation", None)
+    business_parent_id = _fetch_category_id(connection, "Business & Finance", None)
+
+    if tech_parent_id is not None:
+        connection.execute(
+            categories.delete().where(
+                categories.c.name == "Products & Platforms",
+                categories.c.parent_id == tech_parent_id,
+            )
+        )
+    if business_parent_id is not None:
+        connection.execute(
+            categories.delete().where(
+                categories.c.name == "Business News & Market Intelligence",
+                categories.c.parent_id == business_parent_id,
+            )
+        )
+
+    op.drop_index("ix_tag_slug_history_slug", table_name="tag_slug_history")
+    op.drop_index("ix_tag_slug_history_tag_id", table_name="tag_slug_history")
+    op.drop_table("tag_slug_history")
+
+    op.drop_index("ix_category_slug_history_slug", table_name="category_slug_history")
+    op.drop_index("ix_category_slug_history_category_id", table_name="category_slug_history")
+    op.drop_table("category_slug_history")
+
+    op.drop_column("posts", "seo_keywords")
+
+    op.drop_constraint("fk_tags_canonical_tag_id_tags", "tags", type_="foreignkey")
+    op.drop_column("tags", "canonical_tag_id")
+    op.drop_column("tags", "is_active")

--- a/api/alembic/versions/4a8b2f6d9c10_canonicalize_tags_phase1.py
+++ b/api/alembic/versions/4a8b2f6d9c10_canonicalize_tags_phase1.py
@@ -1,0 +1,251 @@
+"""canonicalize tags phase 1
+
+Revision ID: 4a8b2f6d9c10
+Revises: 3e1d8d5f4c21
+Create Date: 2026-04-07 11:40:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import re
+import unicodedata
+
+
+# revision identifiers, used by Alembic.
+revision = "4a8b2f6d9c10"
+down_revision = "3e1d8d5f4c21"
+branch_labels = None
+depends_on = None
+
+
+categories = sa.table(
+    "categories",
+    sa.column("id", sa.Integer()),
+    sa.column("name", sa.String(length=100)),
+)
+
+tags = sa.table(
+    "tags",
+    sa.column("id", sa.Integer()),
+    sa.column("name", sa.String(length=50)),
+    sa.column("slug", sa.String(length=50)),
+    sa.column("category_id", sa.Integer()),
+    sa.column("is_active", sa.Boolean()),
+    sa.column("canonical_tag_id", sa.Integer()),
+)
+
+tag_slug_history = sa.table(
+    "tag_slug_history",
+    sa.column("tag_id", sa.Integer()),
+    sa.column("slug", sa.String(length=50)),
+)
+
+post_tags = sa.table(
+    "post_tags",
+    sa.column("post_id", sa.Integer()),
+    sa.column("tag_id", sa.Integer()),
+)
+
+
+CANONICAL_TAG_DEFINITIONS = {
+    "Automation": "Automation",
+    "Freelancing": "Freelancing",
+    "Online Learning": "Learning & Skill Building",
+    "Productivity Tools": "Productivity & Remote Work",
+    "Creator Platforms": "Creator Business",
+    "Social Media Strategy": "Personal Brand & Audience",
+    "Remote Work": "Productivity & Remote Work",
+    "Financial Independence": "Personal Finance & Investing",
+    "Intentional Living": "Intentional Living",
+    "Personal Growth": "Personal Growth",
+    "Personal Branding": "Personal Brand & Audience",
+    "Professional Portfolio": "Personal Brand & Audience",
+}
+
+TAG_MAPPINGS = {
+    "Zapier": "Automation",
+    "Make": "Automation",
+    "n8n": "Automation",
+    "Workflows": "Automation",
+    "Fiverr": "Freelancing",
+    "Upwork": "Freelancing",
+    "Coursera": "Online Learning",
+    "Udemy": "Online Learning",
+    "Notion": "Productivity Tools",
+    "Obsidian": "Productivity Tools",
+    "Patreon": "Creator Platforms",
+    "Substack": "Creator Platforms",
+    "YouTube": "Creator Platforms",
+    "Podcasting": "Creator Platforms",
+    "Newsletter": "Creator Platforms",
+    "Twitter": "Social Media Strategy",
+    "Social Media": "Social Media Strategy",
+    "Work From Home": "Remote Work",
+    "Productivity Apps": "Productivity Tools",
+    "FIRE": "Financial Independence",
+    "Simple Living": "Intentional Living",
+    "Personal Development": "Personal Growth",
+    "Self-Improvement": "Personal Growth",
+    "Online Presence": "Personal Branding",
+    "Thought Leadership": "Personal Branding",
+    "LinkedIn": "Personal Branding",
+    "Portfolio": "Professional Portfolio",
+}
+
+
+def _slugify(value: str, *, max_length: int = 50) -> str:
+    slug = unicodedata.normalize("NFKD", value.strip().lower())
+    slug = "".join(char for char in slug if not unicodedata.combining(char))
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    slug = re.sub(r"-{2,}", "-", slug).strip("-")
+    return slug[:max_length].strip("-")
+
+
+def _fetch_category_id(connection, name: str):
+    return connection.execute(
+        sa.select(categories.c.id).where(categories.c.name == name)
+    ).scalar_one_or_none()
+
+
+def _fetch_tag(connection, name: str):
+    row = connection.execute(
+        sa.select(
+            tags.c.id,
+            tags.c.name,
+            tags.c.slug,
+            tags.c.category_id,
+            tags.c.is_active,
+            tags.c.canonical_tag_id,
+        ).where(tags.c.name == name)
+    ).mappings().first()
+    return row
+
+
+def _ensure_canonical_tag(connection, tag_name: str) -> int | None:
+    existing = _fetch_tag(connection, tag_name)
+    if existing is not None:
+        connection.execute(
+            tags.update()
+            .where(tags.c.id == existing["id"])
+            .values(is_active=True, canonical_tag_id=None)
+        )
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO tag_slug_history (tag_id, slug)
+                SELECT :tag_id, :slug
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM tag_slug_history
+                    WHERE tag_id = :tag_id
+                      AND slug = :slug
+                )
+                """
+            ),
+            {"tag_id": existing["id"], "slug": existing["slug"]},
+        )
+        return existing["id"]
+
+    category_name = CANONICAL_TAG_DEFINITIONS.get(tag_name)
+    if category_name is None:
+        return None
+
+    category_id = _fetch_category_id(connection, category_name)
+    if category_id is None:
+        return None
+
+    result = connection.execute(
+        tags.insert().values(
+            name=tag_name,
+            slug=_slugify(tag_name),
+            category_id=category_id,
+            is_active=True,
+            canonical_tag_id=None,
+        ).returning(tags.c.id)
+    )
+    tag_id = result.scalar_one()
+    connection.execute(
+        tag_slug_history.insert().values(tag_id=tag_id, slug=_slugify(tag_name))
+    )
+    return tag_id
+
+
+def _merge_tag(connection, old_tag_name: str, canonical_tag_name: str) -> None:
+    old_tag = _fetch_tag(connection, old_tag_name)
+    canonical_id = _ensure_canonical_tag(connection, canonical_tag_name)
+    if old_tag is None or canonical_id is None or old_tag["id"] == canonical_id:
+        return
+
+    connection.execute(
+        sa.text(
+            """
+            INSERT INTO post_tags (post_id, tag_id)
+            SELECT pt.post_id, :canonical_tag_id
+            FROM post_tags pt
+            WHERE pt.tag_id = :old_tag_id
+              AND NOT EXISTS (
+                SELECT 1
+                FROM post_tags existing
+                WHERE existing.post_id = pt.post_id
+                  AND existing.tag_id = :canonical_tag_id
+              )
+            """
+        ),
+        {"old_tag_id": old_tag["id"], "canonical_tag_id": canonical_id},
+    )
+    connection.execute(
+        post_tags.delete().where(post_tags.c.tag_id == old_tag["id"])
+    )
+    connection.execute(
+        tags.update()
+        .where(tags.c.id == old_tag["id"])
+        .values(is_active=False, canonical_tag_id=canonical_id)
+    )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    for canonical_tag_name in CANONICAL_TAG_DEFINITIONS:
+        _ensure_canonical_tag(connection, canonical_tag_name)
+
+    for old_tag_name, canonical_tag_name in TAG_MAPPINGS.items():
+        _merge_tag(connection, old_tag_name, canonical_tag_name)
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+
+    for old_tag_name, canonical_tag_name in TAG_MAPPINGS.items():
+        old_tag = _fetch_tag(connection, old_tag_name)
+        canonical_tag = _fetch_tag(connection, canonical_tag_name)
+        if old_tag is None:
+            continue
+
+        if canonical_tag is not None:
+            connection.execute(
+                sa.text(
+                    """
+                    INSERT INTO post_tags (post_id, tag_id)
+                    SELECT pt.post_id, :old_tag_id
+                    FROM post_tags pt
+                    WHERE pt.tag_id = :canonical_tag_id
+                      AND NOT EXISTS (
+                        SELECT 1
+                        FROM post_tags existing
+                        WHERE existing.post_id = pt.post_id
+                          AND existing.tag_id = :old_tag_id
+                      )
+                    """
+                ),
+                {
+                    "old_tag_id": old_tag["id"],
+                    "canonical_tag_id": canonical_tag["id"],
+                },
+            )
+
+        connection.execute(
+            tags.update()
+            .where(tags.c.id == old_tag["id"])
+            .values(is_active=True, canonical_tag_id=None)
+        )

--- a/api/alembic/versions/b4f7a2c8d901_add_password_reset_and_email_verification_tokens.py
+++ b/api/alembic/versions/b4f7a2c8d901_add_password_reset_and_email_verification_tokens.py
@@ -16,89 +16,111 @@ branch_labels = None
 depends_on = None
 
 
+def _existing_indexes(inspector, table_name: str) -> set[str]:
+    if not inspector.has_table(table_name):
+        return set()
+    return {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def _ensure_index(table_name: str, index_name: str, columns: list[str], *, unique: bool) -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_indexes = _existing_indexes(inspector, table_name)
+    if index_name in existing_indexes:
+        return
+    op.create_index(index_name, table_name, columns, unique=unique)
+
+
 def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
     # Create password_reset_tokens table
-    op.create_table(
+    if not inspector.has_table("password_reset_tokens"):
+        op.create_table(
+            "password_reset_tokens",
+            sa.Column("id", sa.Integer(), nullable=False, autoincrement=True),
+            sa.Column("uuid", sa.String(length=36), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=True,
+            ),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("token", sa.String(length=255), nullable=False),
+            sa.Column("expires_at", sa.DateTime(), nullable=False),
+            sa.Column("used", sa.Boolean(), server_default=sa.text("false"), nullable=True),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        inspector = sa.inspect(bind)
+    _ensure_index(
         "password_reset_tokens",
-        sa.Column("id", sa.Integer(), nullable=False, autoincrement=True),
-        sa.Column("uuid", sa.String(length=36), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.DateTime(),
-            server_default=sa.text("CURRENT_TIMESTAMP"),
-            nullable=False,
-        ),
-        sa.Column(
-            "updated_at",
-            sa.DateTime(),
-            server_default=sa.text("CURRENT_TIMESTAMP"),
-            nullable=True,
-        ),
-        sa.Column("user_id", sa.Integer(), nullable=False),
-        sa.Column("token", sa.String(length=255), nullable=False),
-        sa.Column("expires_at", sa.DateTime(), nullable=False),
-        sa.Column("used", sa.Boolean(), server_default=sa.text("false"), nullable=True),
-        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
         "ix_password_reset_tokens_user_id",
-        "password_reset_tokens",
         ["user_id"],
         unique=False,
     )
-    op.create_index(
-        "ix_password_reset_tokens_token",
+    _ensure_index(
         "password_reset_tokens",
+        "ix_password_reset_tokens_token",
         ["token"],
         unique=True,
     )
-    op.create_index(
-        "ix_password_reset_tokens_uuid",
+    _ensure_index(
         "password_reset_tokens",
+        "ix_password_reset_tokens_uuid",
         ["uuid"],
         unique=True,
     )
 
     # Create email_verification_tokens table
-    op.create_table(
+    if not inspector.has_table("email_verification_tokens"):
+        op.create_table(
+            "email_verification_tokens",
+            sa.Column("id", sa.Integer(), nullable=False, autoincrement=True),
+            sa.Column("uuid", sa.String(length=36), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=True,
+            ),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("token", sa.String(length=255), nullable=False),
+            sa.Column("expires_at", sa.DateTime(), nullable=False),
+            sa.Column("used", sa.Boolean(), server_default=sa.text("false"), nullable=True),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        inspector = sa.inspect(bind)
+    _ensure_index(
         "email_verification_tokens",
-        sa.Column("id", sa.Integer(), nullable=False, autoincrement=True),
-        sa.Column("uuid", sa.String(length=36), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.DateTime(),
-            server_default=sa.text("CURRENT_TIMESTAMP"),
-            nullable=False,
-        ),
-        sa.Column(
-            "updated_at",
-            sa.DateTime(),
-            server_default=sa.text("CURRENT_TIMESTAMP"),
-            nullable=True,
-        ),
-        sa.Column("user_id", sa.Integer(), nullable=False),
-        sa.Column("token", sa.String(length=255), nullable=False),
-        sa.Column("expires_at", sa.DateTime(), nullable=False),
-        sa.Column("used", sa.Boolean(), server_default=sa.text("false"), nullable=True),
-        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
         "ix_email_verification_tokens_user_id",
-        "email_verification_tokens",
         ["user_id"],
         unique=False,
     )
-    op.create_index(
-        "ix_email_verification_tokens_token",
+    _ensure_index(
         "email_verification_tokens",
+        "ix_email_verification_tokens_token",
         ["token"],
         unique=True,
     )
-    op.create_index(
-        "ix_email_verification_tokens_uuid",
+    _ensure_index(
         "email_verification_tokens",
+        "ix_email_verification_tokens_uuid",
         ["uuid"],
         unique=True,
     )

--- a/api/alembic/versions/f1c9e7a4b2d0_rename_taxonomy_subcategories_phase1.py
+++ b/api/alembic/versions/f1c9e7a4b2d0_rename_taxonomy_subcategories_phase1.py
@@ -1,0 +1,129 @@
+"""rename taxonomy subcategories phase 1
+
+Revision ID: f1c9e7a4b2d0
+Revises: 7d6b8e4c2f10
+Create Date: 2026-04-06 18:40:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "f1c9e7a4b2d0"
+down_revision = "7d6b8e4c2f10"
+branch_labels = None
+depends_on = None
+
+
+categories = sa.table(
+    "categories",
+    sa.column("id", sa.Integer()),
+    sa.column("name", sa.String(length=100)),
+)
+
+tags = sa.table(
+    "tags",
+    sa.column("id", sa.Integer()),
+    sa.column("category_id", sa.Integer()),
+)
+
+
+CATEGORY_RENAMES_UP = {
+    46: "Blockchain & Crypto",
+    47: "Automation",
+    48: "Software Development",
+    49: "Cybersecurity & Privacy",
+    53: "Creator Business",
+    54: "Online Business & Marketing",
+    57: "Career Growth & Job Search",
+    58: "Learning & Skill Building",
+    59: "Productivity & Remote Work",
+    60: "Freelancing",
+    61: "Personal Brand & Audience",
+    63: "Mental Health",
+    64: "Personal Growth",
+    65: "Intentional Living",
+    66: "Work-Life Balance",
+}
+
+
+CATEGORY_RENAMES_DOWN = {
+    46: "Blockchain & Cryptocurrencies",
+    47: "Automation & Smart Tools",
+    48: "Programming & Development",
+    49: "Cybersecurity Basics",
+    53: "Creator Economy & Monetization",
+    54: "Online Business Strategies",
+    57: "Career Development & Skills",
+    58: "Online Learning Platforms",
+    59: "Productivity Hacks & Tools",
+    60: "Remote Work & Digital Nomad",
+    61: "Personal Branding",
+    63: "Mental Health & Psychology",
+    64: "Personal Growth & Self-Improvement",
+    65: "Minimalism & Intentional Living",
+    66: "Wellness & Work-Life Balance",
+}
+
+
+TAG_CATEGORY_UPDATES_UP = {
+    205: 59,  # Remote Work -> Productivity & Remote Work
+    206: 59,  # Work From Home -> Productivity & Remote Work
+    207: 59,  # Digital Nomad -> Productivity & Remote Work
+    208: 59,  # Async Work -> Productivity & Remote Work
+    209: 59,  # Home Office -> Productivity & Remote Work
+    240: 60,  # Freelancing -> Freelancing
+    241: 60,  # Upwork -> Freelancing
+    242: 60,  # Fiverr -> Freelancing
+    243: 60,  # Consulting -> Freelancing
+    244: 60,  # Copywriting -> Freelancing
+    245: 60,  # UX Design -> Freelancing
+}
+
+
+TAG_CATEGORY_UPDATES_DOWN = {
+    205: 60,
+    206: 60,
+    207: 60,
+    208: 60,
+    209: 60,
+    240: 57,
+    241: 57,
+    242: 57,
+    243: 57,
+    244: 57,
+    245: 57,
+}
+
+
+def _apply_category_renames(rename_map: dict[int, str]) -> None:
+    connection = op.get_bind()
+    for category_id, new_name in rename_map.items():
+        connection.execute(
+            categories.update()
+            .where(categories.c.id == category_id)
+            .values(name=new_name)
+        )
+
+
+def _apply_tag_category_updates(update_map: dict[int, int]) -> None:
+    connection = op.get_bind()
+    for tag_id, category_id in update_map.items():
+        connection.execute(
+            tags.update()
+            .where(tags.c.id == tag_id)
+            .values(category_id=category_id)
+        )
+
+
+def upgrade() -> None:
+    # Preserve existing category slugs and ids. Only rename the rows in place.
+    _apply_category_renames(CATEGORY_RENAMES_UP)
+    _apply_tag_category_updates(TAG_CATEGORY_UPDATES_UP)
+
+
+def downgrade() -> None:
+    _apply_tag_category_updates(TAG_CATEGORY_UPDATES_DOWN)
+    _apply_category_renames(CATEGORY_RENAMES_DOWN)

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -1,6 +1,6 @@
 from .base import Base
 from .user import User, Profile, UserRoleChange, PasswordResetToken, EmailVerificationToken
-from .post import Post, Category, Tag
+from .post import Post, Category, Tag, CategorySlugHistory, TagSlugHistory
 from .comment import Comment
 from .report import Report
 from .comment_report import CommentReport
@@ -18,6 +18,8 @@ __all__ = [
     'Post',
     'Category',
     'Tag',
+    'CategorySlugHistory',
+    'TagSlugHistory',
     'Comment',
     'Report',
     'CommentReport',

--- a/api/models/post.py
+++ b/api/models/post.py
@@ -1,7 +1,7 @@
 from  datetime import datetime
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, Text, ForeignKey, JSON
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Text, ForeignKey, JSON, text
 from sqlalchemy.orm import relationship
-from .base import  BaseTable, post_tags, post_likes, post_bookmarks
+from .base import  Base, BaseTable, post_tags, post_likes, post_bookmarks
 
 class Category(BaseTable):
     __tablename__ = 'categories'
@@ -14,6 +14,11 @@ class Category(BaseTable):
 
     parent = relationship("Category", remote_side='Category.id', back_populates="subcategories")
     subcategories = relationship("Category", back_populates="parent")
+    slug_history = relationship(
+        "CategorySlugHistory",
+        back_populates="category",
+        cascade="all, delete-orphan",
+    )
 
 
 class Tag(BaseTable):
@@ -22,8 +27,21 @@ class Tag(BaseTable):
     name = Column(String(50), unique=True, nullable=False)
     slug = Column(String(50), unique=True, nullable=False)
     category_id = Column(Integer, ForeignKey('categories.id'), nullable=True)
+    is_active = Column(Boolean, default=True, nullable=False)
+    canonical_tag_id = Column(Integer, ForeignKey('tags.id'), nullable=True)
     posts = relationship("Post", secondary=post_tags, back_populates="tags")
     category = relationship("Category", foreign_keys=[category_id])
+    canonical_tag = relationship(
+        "Tag",
+        remote_side="Tag.id",
+        foreign_keys=[canonical_tag_id],
+        backref="deprecated_variants",
+    )
+    slug_history = relationship(
+        "TagSlugHistory",
+        back_populates="tag",
+        cascade="all, delete-orphan",
+    )
 
 
 class Post(BaseTable):
@@ -43,6 +61,7 @@ class Post(BaseTable):
     reading_time = Column(Integer, nullable=True)
     meta_title = Column(String(200), nullable=True)
     meta_description = Column(String(300), nullable=True)
+    seo_keywords = Column(JSON, nullable=True)
     published_at = Column(DateTime, nullable=True)
     deleted_at = Column(DateTime, nullable=True, default=None)
     is_reviewed = Column(Boolean, default=False, nullable=False)
@@ -67,3 +86,25 @@ class Post(BaseTable):
     @property
     def is_deleted(self):
         return self.deleted_at is not None
+
+
+class CategorySlugHistory(Base):
+    __tablename__ = 'category_slug_history'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    category_id = Column(Integer, ForeignKey('categories.id', ondelete='CASCADE'), nullable=False, index=True)
+    slug = Column(String(100), unique=True, nullable=False, index=True)
+    created_at = Column(DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False)
+
+    category = relationship("Category", back_populates="slug_history")
+
+
+class TagSlugHistory(Base):
+    __tablename__ = 'tag_slug_history'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    tag_id = Column(Integer, ForeignKey('tags.id', ondelete='CASCADE'), nullable=False, index=True)
+    slug = Column(String(50), unique=True, nullable=False, index=True)
+    created_at = Column(DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False)
+
+    tag = relationship("Tag", back_populates="slug_history")

--- a/api/routers/v1/ai.py
+++ b/api/routers/v1/ai.py
@@ -4,7 +4,14 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from database.connection import get_db_session
 from services.user.auth import get_current_active_user
-from services.ai import AIGeneratorService, AIDraftService, BlogAgentService, WebSearchService
+from services.ai import (
+    AIGeneratorService,
+    AIDraftService,
+    BlogAgentService,
+    BlogTaxonomyService,
+    WebSearchService,
+)
+from services.ai.seo_keywords import resolve_seo_keywords
 from services.post import PostService
 from schemas.ai import (
     GenerateRequest,
@@ -19,7 +26,7 @@ from schemas.ai import (
     BlogGenerateResponse,
     BlogPost,
 )
-from schemas.post import PostCreate, TagCreate
+from schemas.post import PostCreate
 from models import User
 from typing import List
 from datetime import datetime, timezone
@@ -318,11 +325,11 @@ async def get_blog_options():
 
     return {
         "blog_types": [
+            {"value": "news", "label": "News Article"},
             {"value": "how-to", "label": "How-To Guide"},
             {"value": "listicle", "label": "Listicle"},
             {"value": "tutorial", "label": "Tutorial"},
             {"value": "opinion", "label": "Opinion/Editorial"},
-            {"value": "news", "label": "News Article"},
             {"value": "review", "label": "Product Review"},
             {"value": "comparison", "label": "Comparison"},
             {"value": "case-study", "label": "Case Study"},
@@ -387,12 +394,16 @@ async def generate_blog(
         # Initialize the blog agent service
         blog_agent = BlogAgentService()
         use_web_search = request.use_web_search
+        seed_keywords = resolve_seo_keywords(
+            topic=request.topic,
+            provided_keywords=request.keywords,
+        )
 
         # Generate the blog post
         blog_post, generation_time, web_search_used, sources = await blog_agent.generate(
             topic=request.topic,
             blog_type=request.blog_type,
-            keywords=request.keywords,
+            keywords=seed_keywords,
             audience=request.audience,
             word_count=request.word_count or "medium",
             tone=request.tone or "professional",
@@ -402,10 +413,23 @@ async def generate_blog(
             use_web_search=use_web_search,
         )
 
+        taxonomy_suggestion = await BlogTaxonomyService.suggest_for_generated_post(
+            db,
+            topic=request.topic,
+            blog_post=blog_post,
+            keywords=seed_keywords,
+            preferred_category_id=request.category_id,
+        )
+        resolved_keywords = resolve_seo_keywords(
+            topic=request.topic,
+            provided_keywords=seed_keywords,
+            blog_post=blog_post,
+            taxonomy_suggestion=taxonomy_suggestion,
+        )
         quality_report = blog_agent.build_quality_report(
             blog_post=blog_post,
             word_count=request.word_count or "medium",
-            keywords=request.keywords,
+            keywords=resolved_keywords,
             phase_metrics=blog_agent.get_last_phase_metrics(),
         )
 
@@ -428,12 +452,20 @@ async def generate_blog(
                         "blog_type": request.blog_type,
                         "seo_title": blog_post.seo_title,
                         "seo_description": blog_post.seo_description,
+                        "resolved_keywords": resolved_keywords,
                         "tags": blog_post.tags,
                         "slug": blog_post.slug,
                         "use_web_search": use_web_search,
                         "web_search_used": web_search_used,
                         "phase_metrics": blog_agent.get_last_phase_metrics(),
                         "quality_report": quality_report,
+                        "taxonomy_suggestion": taxonomy_suggestion.model_dump(
+                            exclude_none=True
+                        ),
+                        "resolved_category_id": taxonomy_suggestion.category.id
+                        if taxonomy_suggestion.category
+                        else None,
+                        "resolved_tag_ids": [tag.id for tag in taxonomy_suggestion.tags],
                     },
                 )
                 saved_draft = await AIDraftService.create_draft(
@@ -456,24 +488,12 @@ async def generate_blog(
                     for section in blog_post.sections
                 )
                 reading_time = max(1, word_count // 200)
-
-                # Create tags if they don't exist and get their IDs
-                tag_ids = []
-                for tag_name in blog_post.tags[:5]:  # Limit to 5 tags
-                    try:
-                        # Try to create or get existing tag
-                        existing_tag = await PostService.get_tag_by_slug(
-                            db, tag_name.lower().replace(" ", "-")
-                        )
-                        if existing_tag:
-                            tag_ids.append(existing_tag.id)
-                        else:
-                            tag_data = TagCreate(name=tag_name)
-                            new_tag = await PostService.create_tag(db, tag_data)
-                            tag_ids.append(new_tag.id)
-                    except Exception:
-                        # Skip tag if creation fails
-                        pass
+                tag_ids = [
+                    tag.id for tag in taxonomy_suggestion.tags[: BlogTaxonomyService.MAX_TAGS]
+                ]
+                category_id = request.category_id
+                if category_id is None and taxonomy_suggestion.category is not None:
+                    category_id = taxonomy_suggestion.category.id
 
                 # Create the post
                 post_content_blocks = {
@@ -484,8 +504,12 @@ async def generate_blog(
                         "web_search_used": web_search_used,
                         "search_sources_count": len(sources or []),
                         "generated_at": datetime.now(timezone.utc).isoformat(),
+                        "resolved_keywords": resolved_keywords,
                         "phase_metrics": blog_agent.get_last_phase_metrics(),
                         "quality_report": quality_report,
+                        "taxonomy_suggestion": taxonomy_suggestion.model_dump(
+                            exclude_none=True
+                        ),
                     }
                 }
 
@@ -497,7 +521,8 @@ async def generate_blog(
                     excerpt=blog_post.summary,
                     meta_title=blog_post.seo_title,
                     meta_description=blog_post.seo_description,
-                    category_id=request.category_id,
+                    seo_keywords=resolved_keywords,
+                    category_id=category_id,
                     tag_ids=tag_ids,
                     reading_time=reading_time,
                     is_published=request.is_published if request.is_published is not None else False,
@@ -514,6 +539,8 @@ async def generate_blog(
 
         return BlogGenerateResponse(
             blog_post=blog_post,
+            resolved_keywords=resolved_keywords,
+            taxonomy_suggestion=taxonomy_suggestion,
             draft_id=draft_id,
             post_id=post_id,
             model_used=request.model,

--- a/api/routers/v1/post.py
+++ b/api/routers/v1/post.py
@@ -21,9 +21,12 @@ from schemas.post import (
     CategoryCreateResponse,
     CategoryResponse,
     CategoryListResponse,
+    CategorySlugResolveResponse,
     TagCreate,
+    TagUpdate,
     TagResponse,
     TagListResponse,
+    TagGroupedListResponse,
     PostStatsResponse,
     ReportCreate,
     ReportResponse
@@ -54,6 +57,27 @@ def _resolve_client_fingerprint(request: Request) -> str:
     )
     user_agent = (request.headers.get("user-agent") or "").strip().lower()[:200]
     return f"{ip}|{user_agent}"
+
+
+def _parse_csv_ints(raw: Optional[str], field_name: str) -> Optional[List[int]]:
+    if raw is None:
+        return None
+    if raw == "":
+        return []
+    try:
+        return [int(item.strip()) for item in raw.split(",") if item.strip()]
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid {field_name} format. Must be comma-separated integers.",
+        ) from exc
+
+
+def _parse_csv_strings(raw: Optional[str]) -> Optional[List[str]]:
+    if raw is None:
+        return None
+    values = [item.strip() for item in raw.split(",") if item.strip()]
+    return values or []
 
 
 @router.get("/trending/", response_model=PostListResponse)
@@ -366,6 +390,7 @@ async def create_post(
         excerpt: Optional[str] = Form(None),
         meta_title: Optional[str] = Form(None),
         meta_description: Optional[str] = Form(None),
+        seo_keywords: Optional[str] = Form(None),
         category_id: Optional[int] = Form(None),
         tag_ids: Optional[str] = Form(None),
         reading_time: Optional[int] = Form(None),
@@ -379,15 +404,8 @@ async def create_post(
     if featured_image and featured_image.filename:
         featured_image_path = await PostService.save_uploaded_file(featured_image, UPLOAD_DIR)
 
-    parsed_tag_ids = []
-    if tag_ids:
-        try:
-            parsed_tag_ids = [int(tag_id.strip()) for tag_id in tag_ids.split(",") if tag_id.strip()]
-        except ValueError:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid tag_ids format. Must be comma-separated integers."
-            )
+    parsed_tag_ids = _parse_csv_ints(tag_ids, "tag_ids") or []
+    parsed_seo_keywords = _parse_csv_strings(seo_keywords)
 
     if not slug:
         generated_slug = await PostService.generate_unique_slug(session, title, Post)
@@ -415,6 +433,7 @@ async def create_post(
             excerpt=excerpt,
             meta_title=meta_title,
             meta_description=meta_description,
+            seo_keywords=parsed_seo_keywords,
             category_id=category_id,
             tag_ids=parsed_tag_ids,
             reading_time=reading_time,
@@ -458,6 +477,7 @@ async def update_post(
         excerpt: Optional[str] = Form(None),
         meta_title: Optional[str] = Form(None),
         meta_description: Optional[str] = Form(None),
+        seo_keywords: Optional[str] = Form(None),
         category_id: Optional[int] = Form(None),
         tag_ids: Optional[str] = Form(None),
         reading_time: Optional[int] = Form(None),
@@ -484,15 +504,8 @@ async def update_post(
     else:
         featured_image_path = existing_post.featured_image
 
-    parsed_tag_ids = None
-    if tag_ids:
-        try:
-            parsed_tag_ids = [int(tag_id.strip()) for tag_id in tag_ids.split(",") if tag_id.strip()]
-        except ValueError:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid tag_ids format. Must be comma-separated integers."
-            )
+    parsed_tag_ids = _parse_csv_ints(tag_ids, "tag_ids")
+    parsed_seo_keywords = _parse_csv_strings(seo_keywords)
 
     # Parse content_blocks JSON if provided
     parsed_blocks = None
@@ -516,6 +529,7 @@ async def update_post(
         'excerpt': excerpt,
         'meta_title': meta_title,
         'meta_description': meta_description,
+        'seo_keywords': parsed_seo_keywords,
         'category_id': category_id,
         'tag_ids': parsed_tag_ids,
         'reading_time': reading_time,
@@ -606,6 +620,49 @@ async def get_categories(
     return {"categories": categories}
 
 
+@router.get("/categories/resolve/{slug:path}", response_model=CategorySlugResolveResponse)
+async def resolve_category_slug(
+        slug: str,
+        session: AsyncSession = Depends(get_db_session)
+):
+    category, matched_slug, redirect_required = await PostService.resolve_category_slug(
+        session,
+        slug,
+    )
+    if not category:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Category not found",
+        )
+
+    counts_result = await session.execute(
+        select(Post.category_id, func.count(Post.id).label("post_count"))
+        .where(Post.deleted_at.is_(None), Post.category_id.is_not(None))
+        .group_by(Post.category_id)
+    )
+    post_counts = {category_id: post_count for category_id, post_count in counts_result.all()}
+
+    category.post_count = post_counts.get(category.id, 0)
+    for subcategory in category.subcategories:
+        subcategory.post_count = post_counts.get(subcategory.id, 0)
+
+    return {
+        "id": category.id,
+        "name": category.name,
+        "slug": category.slug,
+        "description": category.description,
+        "parent_id": category.parent_id,
+        "created_at": category.created_at,
+        "post_count": category.post_count,
+        "subcategories": category.subcategories,
+        "parent": category.parent,
+        "is_subcategory": category.parent_id is not None,
+        "matched_slug": matched_slug,
+        "canonical_slug": category.slug,
+        "redirect_required": redirect_required,
+    }
+
+
 @router.post("/categories/", response_model=CategoryCreateResponse, status_code=status.HTTP_201_CREATED)
 async def create_category(
         category_data: CategoryCreate,
@@ -638,10 +695,13 @@ async def delete_category(
 @router.get("/tags/", response_model=TagListResponse)
 async def get_tags(
         category_id: Optional[int] = None,
+        include_inactive: bool = Query(False),
         session: AsyncSession = Depends(get_db_session)
 ):
     """Get all tags, optionally filtered by category"""
     query = select(Tag)
+    if not include_inactive:
+        query = query.where(Tag.is_active.is_(True), Tag.canonical_tag_id.is_(None))
     if category_id is not None:
         query = query.where(Tag.category_id == category_id)
     result = await session.execute(query)
@@ -649,8 +709,9 @@ async def get_tags(
     return {"tags": tags}
 
 
-@router.get("/tags/grouped/")
+@router.get("/tags/grouped/", response_model=TagGroupedListResponse)
 async def get_tags_grouped(
+        include_inactive: bool = Query(False),
         session: AsyncSession = Depends(get_db_session)
 ):
     """Get tags grouped by category for easier selection when writing articles"""
@@ -672,7 +733,14 @@ async def get_tags_grouped(
         
         # Get tags for this category and its subcategories
         tags_result = await session.execute(
-            select(Tag).where(Tag.category_id.in_(all_category_ids))
+            select(Tag).where(
+                Tag.category_id.in_(all_category_ids),
+                *(
+                    []
+                    if include_inactive
+                    else [Tag.is_active.is_(True), Tag.canonical_tag_id.is_(None)]
+                ),
+            )
         )
         tags = tags_result.scalars().all()
         
@@ -689,7 +757,7 @@ async def get_tags_grouped(
 @router.post("/tags/", response_model=TagResponse, status_code=status.HTTP_201_CREATED)
 async def create_tag(
         tag_data: TagCreate,
-        current_user: User = Depends(get_current_active_user),
+        current_user: User = Depends(get_current_admin_only),
         session: AsyncSession = Depends(get_db_session)
 ):
     return await PostService.create_tag(session, tag_data)
@@ -698,53 +766,20 @@ async def create_tag(
 @router.put("/tags/{tag_id}", response_model=TagResponse)
 async def update_tag(
         tag_id: int,
-        tag_data: TagCreate,
-        current_user: User = Depends(get_current_active_user),
+        tag_data: TagUpdate,
+        current_user: User = Depends(get_current_admin_only),
         session: AsyncSession = Depends(get_db_session)
 ):
-    """Update an existing tag"""
-    # Check if tag exists
-    result = await session.execute(select(Tag).where(Tag.id == tag_id))
-    tag = result.scalar_one_or_none()
-    
-    if not tag:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Tag not found"
-        )
-    
-    # Update tag fields
-    if tag_data.name:
-        tag.name = tag_data.name
-    if tag_data.slug:
-        tag.slug = tag_data.slug
-    if tag_data.category_id is not None:
-        tag.category_id = tag_data.category_id
-    
-    await session.commit()
-    await session.refresh(tag)
-    return tag
+    return await PostService.update_tag(session, tag_id, tag_data)
 
 
 @router.delete("/tags/{tag_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_tag(
         tag_id: int,
-        current_user: User = Depends(get_current_active_user),
+        current_user: User = Depends(get_current_admin_only),
         session: AsyncSession = Depends(get_db_session)
 ):
-    """Delete a tag"""
-    # Check if tag exists
-    result = await session.execute(select(Tag).where(Tag.id == tag_id))
-    tag = result.scalar_one_or_none()
-    
-    if not tag:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Tag not found"
-        )
-    
-    await session.delete(tag)
-    await session.commit()
+    await PostService.delete_tag(session, tag_id)
     return None
 
 

--- a/api/schemas/ai.py
+++ b/api/schemas/ai.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 class GenerateRequest(BaseModel):
     tool_id: str = Field(..., description="ID from AI_TOOLS")
-    model: str = Field(default="claude-sonnet-4.6", description="AI model name (e.g., claude-sonnet-4.6, gpt-5.2)")
+    model: str = Field(default="claude-sonnet-4.6", description="AI model name (e.g., claude-sonnet-4.6, gpt-5.4, glm-5-turbo, qwen-3.6-plus)")
     params: Dict[str, Any] = Field(..., description="Tool-specific fields")
     prompt: Optional[str] = Field(default=None, description="Freeform prompt to use when tool params are incomplete or for generic generation")
     keywords: Optional[List[str] | str] = Field(default=None, description="Primary keywords to guide generation; list or comma-separated string")
@@ -54,7 +54,7 @@ class ExcerptGenerateRequest(BaseModel):
     content: str = Field(..., min_length=50, description="Full article content or plain text")
     model: str = Field(
         default="claude-sonnet-4.6",
-        description="AI model name (e.g., claude-sonnet-4.6, gpt-5.2)",
+        description="AI model name (e.g., claude-sonnet-4.6, gpt-5.4, glm-5-turbo, qwen-3.6-plus)",
     )
     tone: Optional[str] = Field(default="professional", description="Writing tone")
     language: Optional[str] = Field(default="en-US", description="Output language")
@@ -161,14 +161,43 @@ class BlogPost(BaseModel):
             raise ValueError("tags must be unique")
         return normalized
 
+
+class BlogTaxonomyCategory(BaseModel):
+    id: int
+    name: str
+    slug: Optional[str] = None
+    parent_id: Optional[int] = None
+
+
+class BlogTaxonomyTag(BaseModel):
+    id: int
+    name: str
+    slug: Optional[str] = None
+    category_id: Optional[int] = None
+
+
+class BlogTaxonomySuggestion(BaseModel):
+    category: Optional[BlogTaxonomyCategory] = None
+    tags: List[BlogTaxonomyTag] = Field(default_factory=list)
+    confidence_score: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Deterministic confidence score for the taxonomy suggestion",
+    )
+    review_required: bool = Field(
+        default=False,
+        description="Whether the suggestion is low-confidence and should be reviewed before use",
+    )
+
 class BlogGenerateRequest(BaseModel):
     """Request to generate a complete blog post."""
     topic: str = Field(..., min_length=3, max_length=500, description="Blog topic or title idea")
     blog_type: Literal[
         "how-to", "listicle", "tutorial", "opinion", "case-study", "news", "review", "comparison"
-    ] = Field(default="how-to", description="Type of blog post to generate")
+    ] = Field(default="news", description="Type of blog post to generate")
     keywords: Optional[List[str]] = Field(
-        default=None, description="Target SEO keywords"
+        default=None, description="Target SEO keywords. Leave blank to auto-generate suggestions."
     )
     audience: Optional[str] = Field(
         default=None, description="Target audience description"
@@ -180,7 +209,7 @@ class BlogGenerateRequest(BaseModel):
     language: Optional[str] = Field(default="en-US", description="Output language")
     model: str = Field(
         default="claude-sonnet-4.6",
-        description="AI model (claude-sonnet-4.6, gpt-5.2, deepseek-v3.2)"
+        description="AI model (claude-sonnet-4.6, gpt-5.4, glm-5-turbo, kimi-k2.5, qwen-3.6-plus)"
     )
     creativity: Optional[float] = Field(
         default=0.7, ge=0.0, le=1.0, description="Creativity/temperature"
@@ -206,6 +235,14 @@ class BlogGenerateRequest(BaseModel):
 class BlogGenerateResponse(BaseModel):
     """Response from blog generation."""
     blog_post: BlogPost = Field(..., description="Generated blog post")
+    resolved_keywords: List[str] = Field(
+        default_factory=list,
+        description="Normalized SEO keywords used or suggested for this generation",
+    )
+    taxonomy_suggestion: Optional[BlogTaxonomySuggestion] = Field(
+        default=None,
+        description="Database-backed category and tag suggestions for the generated article",
+    )
     draft_id: Optional[str] = Field(
         default=None, description="AI Draft UUID if saved"
     )

--- a/api/schemas/post.py
+++ b/api/schemas/post.py
@@ -47,10 +47,31 @@ class CategoryCreateResponse(CategoryBase, BaseSchema):
 class CategoryListResponse(BaseModel):
     categories: List[CategoryResponse]
 
+
+class CategorySlugResolveResponse(BaseModel):
+    id: int
+    name: str
+    slug: Optional[str] = None
+    description: Optional[str] = None
+    parent_id: Optional[int] = None
+    created_at: datetime
+    post_count: Optional[int] = 0
+    subcategories: List[CategoryChildResponse] = []
+    parent: Optional[CategoryChildResponse] = None
+    is_subcategory: bool = False
+    matched_slug: str
+    canonical_slug: str
+    redirect_required: bool = False
+
 class TagBase(BaseModel):
     name: str = Field(..., min_length=1, max_length=50)
     slug: Optional[str] = Field(None, min_length=1, max_length=50)
     category_id: Optional[int] = Field(None, description="Category ID for grouping tags")
+    is_active: Optional[bool] = Field(default=True, description="Whether the tag can be assigned to new posts")
+    canonical_tag_id: Optional[int] = Field(
+        default=None,
+        description="Canonical replacement tag id when this tag is deprecated",
+    )
 
 
 class TagCreate(TagBase):
@@ -61,6 +82,11 @@ class TagUpdate(BaseModel):
     name: Optional[str] = Field(None, min_length=1, max_length=50)
     slug: Optional[str] = Field(None, min_length=1, max_length=50)
     category_id: Optional[int] = Field(None, description="Category ID for grouping tags")
+    is_active: Optional[bool] = Field(default=None, description="Whether the tag can be assigned to new posts")
+    canonical_tag_id: Optional[int] = Field(
+        default=None,
+        description="Canonical replacement tag id when this tag is deprecated",
+    )
 
 
 class TagResponse(TagBase, BaseSchema):
@@ -105,6 +131,7 @@ class PostCreate(PostBase):
     slug: str = Field(..., min_length=1, max_length=200)
     category_id: Optional[int] = None
     tag_ids: Optional[List[int]] = []
+    seo_keywords: Optional[List[str]] = None
     featured_image: Optional[str] = None
     reading_time: Optional[int] = None
     is_published: Optional[bool] = False
@@ -119,6 +146,7 @@ class PostUpdate(BaseModel):
     excerpt: Optional[str] = Field(None, max_length=500)
     category_id: Optional[int] = None
     tag_ids: Optional[List[int]] = None
+    seo_keywords: Optional[List[str]] = None
     featured_image: Optional[str] = None
     reading_time: Optional[int] = None
     meta_title: Optional[str] = Field(None, max_length=200)
@@ -140,6 +168,7 @@ class PostResponse(BaseModel):
     reading_time: Optional[int]
     meta_title: Optional[str]
     meta_description: Optional[str]
+    seo_keywords: Optional[List[str]]
     published_at: Optional[datetime]
     created_at: datetime
     updated_at: Optional[datetime]

--- a/api/scripts/benchmark_blog_generation.py
+++ b/api/scripts/benchmark_blog_generation.py
@@ -305,7 +305,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--runs-per-mode", type=int, default=20)
     parser.add_argument("--warmup-runs", type=int, default=1)
     parser.add_argument("--search-states", type=str, default="off,on")
-    parser.add_argument("--model", type=str, default="glm-5")
+    parser.add_argument("--model", type=str, default="glm-5-turbo")
     parser.add_argument("--word-count", type=str, default="medium")
     parser.add_argument("--latency-slo-seconds", type=float, default=60.0)
     parser.add_argument("--per-run-timeout-seconds", type=float, default=75.0)

--- a/api/services/ai/__init__.py
+++ b/api/services/ai/__init__.py
@@ -2,7 +2,14 @@ from .generator import AIGeneratorService
 from .drafts import AIDraftService
 from .tools import ToolHandler
 from .blog_agent import BlogAgentService
+from .taxonomy import BlogTaxonomyService
 from .web_search import WebSearchService
 
-__all__ = ["AIGeneratorService", "AIDraftService", "ToolHandler", "BlogAgentService", "WebSearchService"]
-
+__all__ = [
+    "AIGeneratorService",
+    "AIDraftService",
+    "ToolHandler",
+    "BlogAgentService",
+    "BlogTaxonomyService",
+    "WebSearchService",
+]

--- a/api/services/ai/blog_agent.py
+++ b/api/services/ai/blog_agent.py
@@ -738,7 +738,7 @@ class BlogAgentService:
     async def generate(
         self,
         topic: str,
-        blog_type: str = "how-to",
+        blog_type: str = "news",
         keywords: Optional[list[str]] = None,
         audience: Optional[str] = None,
         word_count: str = "medium",

--- a/api/services/ai/llm_config.py
+++ b/api/services/ai/llm_config.py
@@ -24,17 +24,17 @@ AVAILABLE_MODELS = {
         "supports_compat_json": True,
         "blog_enabled": True,
     },
-    "gpt-5.2": {
-        "id": "openai/gpt-5.2",
-        "label": "GPT-5.2",
+    "gpt-5.4": {
+        "id": "openai/gpt-5.4",
+        "label": "GPT-5.4",
         "provider": "OpenAI",
         "supports_structured": True,
         "supports_compat_json": True,
         "blog_enabled": True,
     },
-    "glm-5": {
-        "id": "z-ai/glm-5",
-        "label": "GLM-5",
+    "glm-5-turbo": {
+        "id": "z-ai/glm-5-turbo",
+        "label": "GLM 5 Turbo",
         "provider": "Z.AI",
         "supports_structured": False,
         "supports_compat_json": True,
@@ -48,9 +48,17 @@ AVAILABLE_MODELS = {
         "supports_compat_json": True,
         "blog_enabled": True,
     },
+    "qwen-3.6-plus": {
+        "id": "qwen/qwen3.6-plus",
+        "label": "Qwen 3.6 Plus",
+        "provider": "Qwen",
+        "supports_structured": False,
+        "supports_compat_json": True,
+        "blog_enabled": True,
+    },
 }
 
-DEFAULT_MODEL = "glm-5"
+DEFAULT_MODEL = "glm-5-turbo"
 
 
 def _ensure_api_key():
@@ -110,14 +118,19 @@ def get_model_from_id(model_id: str) -> OpenAIModel:
 def get_models_for_frontend() -> list[dict]:
     """Return the model list formatted for frontend dropdowns."""
     if not settings.OPENROUTER_API_KEY:
+        default_entry = AVAILABLE_MODELS[DEFAULT_MODEL]
         return [
             {
                 "value": DEFAULT_MODEL,
-                "label": f"{AVAILABLE_MODELS[DEFAULT_MODEL]['label']} (needs API key)",
-                "supports_structured": True,
-                "supports_compat_json": True,
-                "blog_enabled": True,
-                "default_path": "structured",
+                "label": f"{default_entry['label']} (needs API key)",
+                "supports_structured": bool(default_entry.get("supports_structured", False)),
+                "supports_compat_json": bool(default_entry.get("supports_compat_json", False)),
+                "blog_enabled": bool(default_entry.get("blog_enabled", False)),
+                "default_path": (
+                    "structured"
+                    if default_entry.get("supports_structured", False)
+                    else "compat_json"
+                ),
             }
         ]
 

--- a/api/services/ai/seo_keywords.py
+++ b/api/services/ai/seo_keywords.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from schemas.ai import BlogPost, BlogTaxonomySuggestion
+
+
+MAX_SEO_KEYWORDS = 6
+_ACRONYMS = {"ai", "api", "aws", "gdp", "ipo", "llm", "llms", "seo", "sql", "ui", "uk", "un", "us", "ux"}
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "article",
+    "for",
+    "how",
+    "in",
+    "news",
+    "of",
+    "on",
+    "or",
+    "the",
+    "to",
+    "with",
+}
+
+
+def _clean_phrase(value: str) -> str:
+    phrase = re.sub(r"\s+", " ", value or "").strip()
+    phrase = phrase.strip(".,:;|/-()[]{} ")
+    return phrase
+
+
+def _canonical_key(value: str) -> str:
+    canonical = _clean_phrase(value).lower()
+    canonical = canonical.replace("&", "and")
+    canonical = re.sub(r"[^a-z0-9\s]", "", canonical)
+    canonical = re.sub(r"\s+", " ", canonical).strip()
+    return canonical
+
+
+def _display_phrase(value: str) -> str:
+    words = re.split(r"\s+", _clean_phrase(value).replace("-", " "))
+    display_words: list[str] = []
+    for word in words:
+        lower = word.lower()
+        if not lower:
+            continue
+        if lower in _ACRONYMS:
+            display_words.append(lower.upper())
+        elif lower.isdigit():
+            display_words.append(lower)
+        else:
+            display_words.append(lower.capitalize())
+    return " ".join(display_words)
+
+
+def _looks_useful(phrase: str) -> bool:
+    canonical = _canonical_key(phrase)
+    if not canonical:
+        return False
+    if canonical in _STOPWORDS:
+        return False
+    words = canonical.split()
+    if len(words) > 10:
+        return False
+    if len(words) == 1 and len(words[0]) < 3:
+        return False
+    return True
+
+
+def _extract_candidate_phrases(text: str) -> list[str]:
+    cleaned = _clean_phrase(text)
+    if not cleaned:
+        return []
+
+    raw_candidates = [cleaned.replace("-", " ")]
+    raw_candidates.extend(
+        part.replace("-", " ")
+        for part in re.split(r"\s*[:,;|/]\s*", cleaned)
+    )
+
+    candidates: list[str] = []
+    for candidate in raw_candidates:
+        normalized = _clean_phrase(candidate)
+        if _looks_useful(normalized):
+            candidates.append(normalized)
+    return candidates
+
+
+def _iter_seed_terms(values: Iterable[str] | None) -> Iterable[str]:
+    for value in values or []:
+        if value and value.strip():
+            yield value
+
+
+def resolve_seo_keywords(
+    *,
+    topic: str,
+    provided_keywords: list[str] | None = None,
+    blog_post: BlogPost | None = None,
+    taxonomy_suggestion: BlogTaxonomySuggestion | None = None,
+) -> list[str]:
+    resolved: list[str] = []
+    seen: set[str] = set()
+
+    def add_phrase(phrase: str) -> None:
+        if len(resolved) >= MAX_SEO_KEYWORDS:
+            return
+        canonical = _canonical_key(phrase)
+        if not canonical or canonical in seen:
+            return
+        if not _looks_useful(phrase):
+            return
+        resolved.append(_display_phrase(phrase))
+        seen.add(canonical)
+
+    def add_source(source: str) -> None:
+        for phrase in _extract_candidate_phrases(source):
+            add_phrase(phrase)
+            if len(resolved) >= MAX_SEO_KEYWORDS:
+                return
+
+    for keyword in _iter_seed_terms(provided_keywords):
+        add_source(keyword)
+
+    add_source(topic)
+
+    if blog_post is not None:
+        add_source(blog_post.title)
+        for tag in _iter_seed_terms(blog_post.tags):
+            add_source(tag)
+
+    if taxonomy_suggestion is not None:
+        if taxonomy_suggestion.category is not None:
+            add_source(taxonomy_suggestion.category.name)
+        for tag in taxonomy_suggestion.tags:
+            add_source(tag.name)
+
+    return resolved[:MAX_SEO_KEYWORDS]

--- a/api/services/ai/taxonomy.py
+++ b/api/services/ai/taxonomy.py
@@ -1,0 +1,398 @@
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import Category, Tag
+from schemas.ai import (
+    BlogPost,
+    BlogTaxonomyCategory,
+    BlogTaxonomySuggestion,
+    BlogTaxonomyTag,
+)
+
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_STOP_WORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "for",
+    "from",
+    "how",
+    "in",
+    "into",
+    "of",
+    "on",
+    "or",
+    "the",
+    "to",
+    "with",
+}
+
+
+def _normalize_phrase(value: Optional[str]) -> str:
+    return " ".join(_TOKEN_RE.findall((value or "").lower()))
+
+
+def _tokenize(value: Optional[str]) -> set[str]:
+    return {
+        token
+        for token in _TOKEN_RE.findall((value or "").lower())
+        if len(token) > 1 and token not in _STOP_WORDS
+    }
+
+
+@dataclass
+class _CategoryRecord:
+    category: Category
+    phrase: str
+    slug_phrase: str
+    tokens: set[str]
+
+
+@dataclass
+class _TagRecord:
+    tag: Tag
+    phrase: str
+    slug_phrase: str
+    tokens: set[str]
+
+
+class BlogTaxonomyService:
+    MAX_TAGS = 5
+    LOW_CONFIDENCE_THRESHOLD = 0.45
+
+    @staticmethod
+    async def suggest_for_generated_post(
+        session: AsyncSession | None,
+        *,
+        topic: str,
+        blog_post: BlogPost,
+        keywords: Optional[list[str]] = None,
+        preferred_category_id: Optional[int] = None,
+    ) -> BlogTaxonomySuggestion:
+        if session is None:
+            return BlogTaxonomySuggestion()
+
+        categories_result = await session.execute(select(Category))
+        tags_result = await session.execute(
+            select(Tag).where(Tag.is_active.is_(True), Tag.canonical_tag_id.is_(None))
+        )
+        categories = categories_result.scalars().all()
+        tags = tags_result.scalars().all()
+
+        if not categories:
+            return BlogTaxonomySuggestion()
+
+        resolver = _TaxonomyResolver(categories=categories, tags=tags)
+        return resolver.resolve(
+            topic=topic,
+            blog_post=blog_post,
+            keywords=keywords,
+            preferred_category_id=preferred_category_id,
+        )
+
+
+class _TaxonomyResolver:
+    def __init__(self, *, categories: list[Category], tags: list[Tag]):
+        self.categories = categories
+        self.tags = tags
+        self.categories_by_id = {category.id: category for category in categories}
+        self.child_ids_by_parent: dict[int, set[int]] = defaultdict(set)
+        for category in categories:
+            if category.parent_id:
+                self.child_ids_by_parent[category.parent_id].add(category.id)
+
+        self.category_records = [
+            _CategoryRecord(
+                category=category,
+                phrase=_normalize_phrase(category.name),
+                slug_phrase=_normalize_phrase(category.slug),
+                tokens=_tokenize(f"{category.name} {category.slug}"),
+            )
+            for category in categories
+        ]
+        self.tag_records = [
+            _TagRecord(
+                tag=tag,
+                phrase=_normalize_phrase(tag.name),
+                slug_phrase=_normalize_phrase(tag.slug),
+                tokens=_tokenize(f"{tag.name} {tag.slug}"),
+            )
+            for tag in tags
+        ]
+
+    def resolve(
+        self,
+        *,
+        topic: str,
+        blog_post: BlogPost,
+        keywords: Optional[list[str]],
+        preferred_category_id: Optional[int],
+    ) -> BlogTaxonomySuggestion:
+        full_text = " ".join(
+            filter(
+                None,
+                [
+                    topic,
+                    blog_post.title,
+                    blog_post.summary,
+                    " ".join(section.heading for section in blog_post.sections),
+                    " ".join(blog_post.tags or []),
+                    " ".join(keywords or []),
+                ],
+            )
+        )
+        full_phrase = _normalize_phrase(full_text)
+        full_tokens = _tokenize(full_text)
+        title_summary_phrase = _normalize_phrase(
+            " ".join(filter(None, [topic, blog_post.title, blog_post.summary]))
+        )
+        title_summary_tokens = _tokenize(
+            " ".join(filter(None, [topic, blog_post.title, blog_post.summary]))
+        )
+        keyword_phrases = {_normalize_phrase(keyword) for keyword in (keywords or []) if keyword}
+        keyword_token_sets = [_tokenize(keyword) for keyword in (keywords or []) if keyword]
+        ai_tag_phrases = {_normalize_phrase(tag) for tag in (blog_post.tags or []) if tag}
+        ai_tag_token_sets = [_tokenize(tag) for tag in (blog_post.tags or []) if tag]
+
+        tag_scores: dict[int, int] = {}
+        for record in self.tag_records:
+            score = 0
+
+            if record.phrase and record.phrase in ai_tag_phrases:
+                score += 18
+            if record.slug_phrase and record.slug_phrase in ai_tag_phrases:
+                score += 16
+
+            score += self._best_overlap_bonus(record.tokens, ai_tag_token_sets, 10, 4)
+            score += self._best_overlap_bonus(record.tokens, keyword_token_sets, 8, 3)
+
+            if record.phrase and record.phrase in keyword_phrases:
+                score += 14
+            if record.phrase and record.phrase in title_summary_phrase:
+                score += 10
+            if record.slug_phrase and record.slug_phrase in title_summary_phrase:
+                score += 8
+            if record.phrase and record.phrase in full_phrase:
+                score += 6
+
+            overlap = len(record.tokens & full_tokens)
+            score += overlap * 2
+            if record.tokens and record.tokens.issubset(title_summary_tokens):
+                score += 4
+
+            if score > 0:
+                tag_scores[record.tag.id] = score
+
+        category_scores: dict[int, int] = defaultdict(int)
+        for record in self.category_records:
+            score = 0
+
+            if record.phrase and record.phrase in title_summary_phrase:
+                score += 18
+            if record.slug_phrase and record.slug_phrase in title_summary_phrase:
+                score += 12
+            if record.phrase and record.phrase in full_phrase:
+                score += 8
+
+            overlap = len(record.tokens & full_tokens)
+            score += overlap * 3
+
+            if record.category.parent_id:
+                parent = self.categories_by_id.get(record.category.parent_id)
+                if parent:
+                    parent_tokens = _tokenize(f"{parent.name} {parent.slug}")
+                    score += len(parent_tokens & full_tokens)
+
+            if score > 0:
+                category_scores[record.category.id] += score
+
+        for tag_record in self.tag_records:
+            score = tag_scores.get(tag_record.tag.id)
+            if not score or not tag_record.tag.category_id:
+                continue
+            category_scores[tag_record.tag.category_id] += score * 3
+            parent_id = self.categories_by_id.get(tag_record.tag.category_id).parent_id
+            if parent_id:
+                category_scores[parent_id] += score
+
+        chosen_category = self._pick_category(category_scores, preferred_category_id)
+        chosen_tag_records = self._pick_tags(tag_scores, chosen_category)
+        confidence_score = self._calculate_confidence(
+            category_scores=category_scores,
+            tag_scores=tag_scores,
+            chosen_category=chosen_category,
+            chosen_tag_records=chosen_tag_records,
+        )
+        review_required = confidence_score < BlogTaxonomyService.LOW_CONFIDENCE_THRESHOLD
+
+        if review_required and preferred_category_id is None:
+            return BlogTaxonomySuggestion(
+                confidence_score=confidence_score,
+                review_required=True,
+            )
+
+        return BlogTaxonomySuggestion(
+            category=self._to_category_payload(chosen_category),
+            tags=[self._to_tag_payload(record.tag) for record in chosen_tag_records],
+            confidence_score=confidence_score,
+            review_required=review_required,
+        )
+
+    def _pick_category(
+        self,
+        category_scores: dict[int, int],
+        preferred_category_id: Optional[int],
+    ) -> Optional[Category]:
+        if preferred_category_id:
+            return self.categories_by_id.get(preferred_category_id)
+
+        if not category_scores:
+            return None
+
+        chosen_id = max(
+            category_scores,
+            key=lambda category_id: (
+                category_scores[category_id],
+                bool(self.categories_by_id[category_id].parent_id),
+                self.categories_by_id[category_id].id,
+            ),
+        )
+        return self.categories_by_id.get(chosen_id)
+
+    def _pick_tags(
+        self,
+        tag_scores: dict[int, int],
+        chosen_category: Optional[Category],
+    ) -> list[_TagRecord]:
+        if not tag_scores:
+            return []
+
+        allowed_category_ids: Optional[set[int]] = None
+        if chosen_category is not None:
+            allowed_category_ids = {chosen_category.id}
+            allowed_category_ids.update(self.child_ids_by_parent.get(chosen_category.id, set()))
+
+        scored_records = [
+            record
+            for record in self.tag_records
+            if record.tag.id in tag_scores
+            and (
+                allowed_category_ids is None
+                or record.tag.category_id in allowed_category_ids
+            )
+        ]
+        scored_records.sort(
+            key=lambda record: (
+                tag_scores[record.tag.id],
+                bool(record.phrase),
+                record.tag.id,
+            ),
+            reverse=True,
+        )
+
+        selected: list[_TagRecord] = []
+        minimum_score = 6 if scored_records else 0
+        for record in scored_records:
+            if tag_scores[record.tag.id] < minimum_score and len(selected) >= 2:
+                break
+            selected.append(record)
+            if len(selected) >= BlogTaxonomyService.MAX_TAGS:
+                return selected
+
+        if len(selected) >= BlogTaxonomyService.MAX_TAGS or not chosen_category:
+            return selected
+
+        fallback_records = [
+            record
+            for record in scored_records
+            if record not in selected and tag_scores[record.tag.id] >= 3
+        ]
+        for record in fallback_records:
+            selected.append(record)
+            if len(selected) >= BlogTaxonomyService.MAX_TAGS:
+                break
+
+        return selected
+
+    def _calculate_confidence(
+        self,
+        *,
+        category_scores: dict[int, int],
+        tag_scores: dict[int, int],
+        chosen_category: Optional[Category],
+        chosen_tag_records: list[_TagRecord],
+    ) -> float:
+        if chosen_category is None and not chosen_tag_records:
+            return 0.0
+
+        category_component = 0.0
+        if chosen_category is not None:
+            chosen_score = category_scores.get(chosen_category.id, 0)
+            ranked_category_ids = sorted(
+                category_scores,
+                key=lambda category_id: (
+                    category_scores[category_id],
+                    bool(self.categories_by_id[category_id].parent_id),
+                    self.categories_by_id[category_id].id,
+                ),
+                reverse=True,
+            )
+            runner_up_score = 0
+            for category_id in ranked_category_ids:
+                if category_id != chosen_category.id:
+                    runner_up_score = category_scores[category_id]
+                    break
+
+            saturation = min(chosen_score / 30, 1.0)
+            dominance = max(chosen_score - runner_up_score, 0) / max(chosen_score, 1)
+            category_component = (saturation * 0.55) + (dominance * 0.25)
+
+        tag_component = 0.0
+        if chosen_tag_records:
+            average_tag_score = sum(
+                tag_scores.get(record.tag.id, 0) for record in chosen_tag_records
+            ) / max(len(chosen_tag_records), 1)
+            tag_component = min(average_tag_score / 18, 1.0) * 0.2
+
+        return round(min(category_component + tag_component, 1.0), 2)
+
+    @staticmethod
+    def _best_overlap_bonus(
+        tag_tokens: set[str],
+        candidate_token_sets: list[set[str]],
+        base_bonus: int,
+        per_token_bonus: int,
+    ) -> int:
+        best = 0
+        for candidate_tokens in candidate_token_sets:
+            overlap = len(tag_tokens & candidate_tokens)
+            if overlap:
+                best = max(best, base_bonus + (overlap * per_token_bonus))
+        return best
+
+    @staticmethod
+    def _to_category_payload(category: Optional[Category]) -> Optional[BlogTaxonomyCategory]:
+        if category is None:
+            return None
+        return BlogTaxonomyCategory(
+            id=category.id,
+            name=category.name,
+            slug=category.slug,
+            parent_id=category.parent_id,
+        )
+
+    @staticmethod
+    def _to_tag_payload(tag: Tag) -> BlogTaxonomyTag:
+        return BlogTaxonomyTag(
+            id=tag.id,
+            name=tag.name,
+            slug=tag.slug,
+            category_id=tag.category_id,
+        )

--- a/api/services/post/post.py
+++ b/api/services/post/post.py
@@ -8,7 +8,17 @@ from html import unescape
 import hashlib
 import time
 import re
-from models import Post, Category, Tag, User, Report, Comment
+import unicodedata
+from models import (
+    Post,
+    Category,
+    Tag,
+    User,
+    Report,
+    Comment,
+    CategorySlugHistory,
+    TagSlugHistory,
+)
 from models.base import post_likes, post_bookmarks
 from schemas.post import (
     PostCreate,
@@ -16,6 +26,7 @@ from schemas.post import (
     CategoryCreate,
     CategoryUpdate,
     TagCreate,
+    TagUpdate,
     ReportCreate
 )
 from utils.slug_generator import generate_slug, generate_random_slug
@@ -38,6 +49,8 @@ ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".avif",
 class PostService:
     EXCERPT_MIN_CHARACTERS = 70
     EXCERPT_MIN_WORDS = 10
+    TAXONOMY_SLUG_MAX_LENGTH = 100
+    TAG_SLUG_MAX_LENGTH = 50
     RELATED_KEYWORD_STOP_WORDS = {
         "about",
         "after",
@@ -80,6 +93,218 @@ class PostService:
     def normalize_excerpt(excerpt: Optional[str]) -> Optional[str]:
         normalized = PostService.normalize_text(excerpt)
         return normalized or None
+
+    @staticmethod
+    def normalize_seo_keywords(keywords: Optional[List[str]]) -> Optional[List[str]]:
+        if keywords is None:
+            return None
+
+        normalized_keywords: list[str] = []
+        seen: set[str] = set()
+        for keyword in keywords:
+            cleaned = re.sub(r"\s+", " ", str(keyword or "").strip())
+            if not cleaned:
+                continue
+            canonical = cleaned.lower()
+            if canonical in seen:
+                continue
+            normalized_keywords.append(cleaned)
+            seen.add(canonical)
+
+        return normalized_keywords or None
+
+    @staticmethod
+    def normalize_taxonomy_slug(value: str, *, max_length: int) -> str:
+        if not value or not value.strip():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Slug cannot be empty",
+            )
+
+        slug = unicodedata.normalize("NFKD", value.strip().lower())
+        slug = "".join(char for char in slug if not unicodedata.combining(char))
+        slug = re.sub(r"[^a-z0-9]+", "-", slug)
+        slug = re.sub(r"-{2,}", "-", slug).strip("-")
+
+        if not slug:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Slug must contain at least one letter or number",
+            )
+
+        return slug[:max_length].strip("-")
+
+    @staticmethod
+    def _taxonomy_history_owner_field(history_model):
+        if history_model is CategorySlugHistory:
+            return CategorySlugHistory.category_id
+        if history_model is TagSlugHistory:
+            return TagSlugHistory.tag_id
+        raise ValueError("Unsupported history model")
+
+    @staticmethod
+    async def _slug_in_use(
+        session: AsyncSession,
+        model,
+        history_model,
+        slug: str,
+        *,
+        exclude_id: Optional[int] = None,
+    ) -> bool:
+        current_query = select(model.id).where(model.slug == slug)
+        if exclude_id is not None:
+            current_query = current_query.where(model.id != exclude_id)
+        current_result = await session.execute(current_query.limit(1))
+        if current_result.scalar_one_or_none() is not None:
+            return True
+
+        owner_field = PostService._taxonomy_history_owner_field(history_model)
+        history_query = select(history_model.id).where(history_model.slug == slug)
+        if exclude_id is not None:
+            history_query = history_query.where(owner_field != exclude_id)
+        history_result = await session.execute(history_query.limit(1))
+        return history_result.scalar_one_or_none() is not None
+
+    @staticmethod
+    async def _record_slug_history(
+        session: AsyncSession,
+        *,
+        history_model,
+        owner_id: int,
+        slug: Optional[str],
+    ) -> None:
+        if not slug:
+            return
+
+        owner_field = PostService._taxonomy_history_owner_field(history_model)
+        existing = await session.execute(
+            select(history_model.id).where(
+                history_model.slug == slug,
+                owner_field == owner_id,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            return
+
+        payload = {"slug": slug}
+        if history_model is CategorySlugHistory:
+            payload["category_id"] = owner_id
+        else:
+            payload["tag_id"] = owner_id
+        session.add(history_model(**payload))
+
+    @staticmethod
+    async def generate_unique_taxonomy_slug(
+        session: AsyncSession,
+        title: str,
+        model,
+        history_model,
+        *,
+        max_length: int,
+        max_attempts: int = 25,
+    ) -> str:
+        base_slug = PostService.normalize_taxonomy_slug(title, max_length=max_length)
+        candidate = base_slug
+        attempt = 1
+        while await PostService._slug_in_use(session, model, history_model, candidate):
+            suffix = str(attempt + 1)
+            trimmed_base = base_slug[: max_length - len(suffix) - 1].strip("-")
+            candidate = f"{trimmed_base}-{suffix}" if trimmed_base else suffix
+            attempt += 1
+            if attempt > max_attempts:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Failed to generate a unique slug",
+                )
+        return candidate
+
+    @staticmethod
+    async def _validate_category_exists(
+        session: AsyncSession,
+        category_id: Optional[int],
+    ) -> None:
+        if category_id is None:
+            return
+
+        result = await session.execute(select(Category.id).where(Category.id == category_id))
+        if result.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Category not found",
+            )
+
+    @staticmethod
+    async def _validate_tags_match_category_branch(
+        session: AsyncSession,
+        *,
+        category_id: Optional[int],
+        tags: List[Tag],
+    ) -> None:
+        if category_id is None or not tags:
+            return
+
+        tag_category_ids = {tag.category_id for tag in tags if tag.category_id is not None}
+        if not tag_category_ids:
+            return
+
+        category_rows = await session.execute(select(Category.id, Category.parent_id))
+        parent_by_id = {row[0]: row[1] for row in category_rows.all()}
+
+        def lineage(category_value: int) -> set[int]:
+            lineage_ids: set[int] = set()
+            current_id: Optional[int] = category_value
+            while current_id is not None and current_id not in lineage_ids:
+                lineage_ids.add(current_id)
+                current_id = parent_by_id.get(current_id)
+            return lineage_ids
+
+        selected_lineage = lineage(category_id)
+        if not selected_lineage:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Category not found",
+            )
+
+        for tag_category_id in tag_category_ids:
+            tag_lineage = lineage(tag_category_id)
+            if not tag_lineage:
+                continue
+
+            # Allow parent<->child lineage matches while blocking sibling branches.
+            if category_id not in tag_lineage and tag_category_id not in selected_lineage:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Selected tags must belong to the chosen category branch",
+                )
+
+    @staticmethod
+    async def resolve_category_slug(
+        session: AsyncSession,
+        slug: str,
+    ) -> tuple[Optional[Category], str, bool]:
+        normalized_slug = slug.strip()
+
+        current_result = await session.execute(
+            select(Category)
+            .where(Category.slug == normalized_slug)
+            .options(selectinload(Category.parent), selectinload(Category.subcategories))
+        )
+        category = current_result.scalar_one_or_none()
+        if category is not None:
+            return category, normalized_slug, False
+
+        history_result = await session.execute(
+            select(Category, CategorySlugHistory.slug)
+            .join(CategorySlugHistory, CategorySlugHistory.category_id == Category.id)
+            .where(CategorySlugHistory.slug == normalized_slug)
+            .options(selectinload(Category.parent), selectinload(Category.subcategories))
+        )
+        matched = history_result.first()
+        if matched is None:
+            return None, normalized_slug, False
+
+        category, matched_slug = matched
+        return category, matched_slug, category.slug != matched_slug
 
     @staticmethod
     def extract_related_keywords(*values: Optional[str]) -> set[str]:
@@ -688,7 +913,9 @@ class PostService:
                 db_post.content_blocks,
             )
             db_post.is_published = True
-            db_post.published_at = datetime.utcnow()
+            if not db_post.published_at:
+                db_post.published_at = datetime.utcnow()
+            db_post.updated_at = datetime.utcnow()
             await session.commit()
             await session.refresh(db_post)
             
@@ -725,6 +952,7 @@ class PostService:
 
             db_post.is_published = False
             db_post.published_at = None
+            db_post.updated_at = datetime.utcnow()
             await session.commit()
             await session.refresh(db_post)
             return db_post
@@ -935,8 +1163,6 @@ class PostService:
             conditions = []
             if published_only:
                 conditions.append(Post.is_published == True)
-            else:
-                conditions.append(Post.is_published == False)
 
             if author_id:
                 conditions.append(Post.author_id == author_id)
@@ -974,8 +1200,6 @@ class PostService:
             conditions = []
             if published_only:
                 conditions.append(Post.is_published == True)
-            else:
-                conditions.append(Post.is_published == False)
 
             if is_featured:
                 conditions.append(Post.is_featured == is_featured)
@@ -1024,6 +1248,10 @@ class PostService:
 
             post_payload = post_data.model_dump(exclude={"tag_ids"})
             post_payload["excerpt"] = normalized_excerpt
+            post_payload["seo_keywords"] = PostService.normalize_seo_keywords(
+                post_data.seo_keywords
+            )
+            await PostService._validate_category_exists(session, post_payload.get("category_id"))
             db_post = Post(
                 **post_payload,
                 author_id=author_id
@@ -1036,6 +1264,11 @@ class PostService:
 
             if post_data.tag_ids:
                 tags = await PostService.get_tags_by_ids(session, post_data.tag_ids)
+                await PostService._validate_tags_match_category_branch(
+                    session,
+                    category_id=post_payload.get("category_id"),
+                    tags=tags,
+                )
                 db_post.tags.extend(tags)
 
             session.add(db_post)
@@ -1074,10 +1307,24 @@ class PostService:
             update_data = post_data.model_dump(exclude_unset=True, exclude={"tag_ids"})
             if "excerpt" in update_data:
                 update_data["excerpt"] = PostService.normalize_excerpt(update_data["excerpt"])
+            if "seo_keywords" in update_data:
+                update_data["seo_keywords"] = PostService.normalize_seo_keywords(
+                    update_data["seo_keywords"]
+                )
 
             if post_data.tag_ids is not None:
                 tags = await PostService.get_tags_by_ids(session, post_data.tag_ids)
                 db_post.tags = tags
+            else:
+                tags = list(db_post.tags)
+
+            final_category_id = update_data.get("category_id", db_post.category_id)
+            await PostService._validate_category_exists(session, final_category_id)
+            await PostService._validate_tags_match_category_branch(
+                session,
+                category_id=final_category_id,
+                tags=tags,
+            )
 
             should_publish = update_data.get("is_published")
             if should_publish is None:
@@ -1094,6 +1341,8 @@ class PostService:
                 )
                 update_data["excerpt"] = validated_excerpt
 
+            was_published = db_post.is_published
+            existing_published_at = db_post.published_at
             for field, value in update_data.items():
                 setattr(db_post, field, value)
 
@@ -1101,7 +1350,10 @@ class PostService:
             if post_data.is_published is not None:
                 if post_data.is_published:
                     db_post.is_published = True
-                    db_post.published_at = datetime.utcnow()
+                    if not was_published or not existing_published_at:
+                        db_post.published_at = datetime.utcnow()
+                    else:
+                        db_post.published_at = existing_published_at
                 else:
                     db_post.is_published = False
                     db_post.published_at = None
@@ -1436,14 +1688,23 @@ class PostService:
             category_data: CategoryCreate
     ) -> Category:
         try:
+            await PostService._validate_category_exists(session, category_data.parent_id)
             if not category_data.slug or not category_data.slug.strip():
-                generated_slug = await PostService.generate_unique_slug(session, category_data.name, Category)
-            else:
-                generated_slug = category_data.slug.strip()
-                existing_category = await session.execute(
-                    select(Category).where(Category.slug == generated_slug)
+                generated_slug = await PostService.generate_unique_taxonomy_slug(
+                    session,
+                    category_data.name,
+                    Category,
+                    CategorySlugHistory,
+                    max_length=PostService.TAXONOMY_SLUG_MAX_LENGTH,
                 )
-                if existing_category.scalar_one_or_none():
+            else:
+                generated_slug = PostService.normalize_taxonomy_slug(
+                    category_data.slug,
+                    max_length=PostService.TAXONOMY_SLUG_MAX_LENGTH,
+                )
+                if await PostService._slug_in_use(
+                    session, Category, CategorySlugHistory, generated_slug
+                ):
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
                         detail="Category with this slug already exists"
@@ -1458,8 +1719,12 @@ class PostService:
 
             session.add(db_category)
             await session.commit()
-            await session.refresh(db_category)
-            return db_category
+            result = await session.execute(
+                select(Category)
+                .where(Category.id == db_category.id)
+                .options(selectinload(Category.parent), selectinload(Category.subcategories))
+            )
+            return result.scalar_one()
         except HTTPException:
             raise
         except Exception as e:
@@ -1487,29 +1752,34 @@ class PostService:
                     detail="Category not found"
                 )
 
-            # Update fields if provided
             if category_data.name is not None:
                 db_category.name = category_data.name
-                
-                # Generate new slug if name changed and no slug provided
-                if category_data.slug is None:
-                    generated_slug = await PostService.generate_unique_slug(session, category_data.name, Category)
-                    db_category.slug = generated_slug
             
             if category_data.slug is not None:
                 if category_data.slug.strip():
-                    existing_category = await session.execute(
-                        select(Category).where(
-                            Category.slug == category_data.slug.strip(),
-                            Category.id != category_id
-                        )
+                    normalized_slug = PostService.normalize_taxonomy_slug(
+                        category_data.slug,
+                        max_length=PostService.TAXONOMY_SLUG_MAX_LENGTH,
                     )
-                    if existing_category.scalar_one_or_none():
+                    if await PostService._slug_in_use(
+                        session,
+                        Category,
+                        CategorySlugHistory,
+                        normalized_slug,
+                        exclude_id=category_id,
+                    ):
                         raise HTTPException(
                             status_code=status.HTTP_400_BAD_REQUEST,
                             detail="Category with this slug already exists"
                         )
-                    db_category.slug = category_data.slug.strip()
+                    if normalized_slug != db_category.slug:
+                        await PostService._record_slug_history(
+                            session,
+                            history_model=CategorySlugHistory,
+                            owner_id=db_category.id,
+                            slug=db_category.slug,
+                        )
+                        db_category.slug = normalized_slug
             
             if category_data.description is not None:
                 db_category.description = category_data.description
@@ -1522,7 +1792,6 @@ class PostService:
                         detail="Category cannot be its own parent"
                     )
                 if category_data.parent_id > 0:
-                    # Verify parent exists
                     parent_result = await session.execute(
                         select(Category).where(Category.id == category_data.parent_id)
                     )
@@ -1532,7 +1801,6 @@ class PostService:
                             status_code=status.HTTP_404_NOT_FOUND,
                             detail="Parent category not found"
                         )
-                    # Check that parent is not a subcategory of this category (prevent circular reference)
                     if parent_category.parent_id == category_id:
                         raise HTTPException(
                             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1540,12 +1808,15 @@ class PostService:
                         )
                     db_category.parent_id = category_data.parent_id
                 else:
-                    # parent_id = 0 means make it a top-level category
                     db_category.parent_id = None
 
             await session.commit()
-            await session.refresh(db_category)
-            return db_category
+            result = await session.execute(
+                select(Category)
+                .where(Category.id == db_category.id)
+                .options(selectinload(Category.parent), selectinload(Category.subcategories))
+            )
+            return result.scalar_one()
         except HTTPException:
             raise
         except Exception as e:
@@ -1632,7 +1903,17 @@ class PostService:
                 .where(Tag.slug == slug)
                 .options(selectinload(Tag.posts))
             )
-            return result.scalar_one_or_none()
+            tag = result.scalar_one_or_none()
+            if tag is not None:
+                return tag
+
+            history_result = await session.execute(
+                select(Tag)
+                .join(TagSlugHistory, TagSlugHistory.tag_id == Tag.id)
+                .where(TagSlugHistory.slug == slug)
+                .options(selectinload(Tag.posts))
+            )
+            return history_result.scalar_one_or_none()
         except Exception as e:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1645,11 +1926,49 @@ class PostService:
             tag_ids: List[int]
     ) -> List[Tag]:
         try:
+            if not tag_ids:
+                return []
+            requested_ids = list(dict.fromkeys(tag_ids))
             result = await session.execute(
                 select(Tag)
-                .where(Tag.id.in_(tag_ids))
+                .options(selectinload(Tag.canonical_tag))
+                .where(
+                    Tag.id.in_(requested_ids),
+                )
             )
-            return result.scalars().all()
+            fetched_tags = {tag.id: tag for tag in result.scalars().all()}
+            if len(fetched_tags) != len(requested_ids):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="One or more selected tags are unavailable",
+                )
+
+            resolved_tags: dict[int, Tag] = {}
+            ordered_resolved_tags: list[Tag] = []
+            for requested_id in requested_ids:
+                tag = fetched_tags[requested_id]
+                target_tag = tag
+                if not tag.is_active or tag.canonical_tag_id is not None:
+                    target_tag = tag.canonical_tag
+                    if (
+                        target_tag is None
+                        or not target_tag.is_active
+                        or target_tag.canonical_tag_id is not None
+                    ):
+                        raise HTTPException(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="One or more selected tags are unavailable",
+                        )
+
+                if target_tag.id in resolved_tags:
+                    continue
+
+                resolved_tags[target_tag.id] = target_tag
+                ordered_resolved_tags.append(target_tag)
+
+            return ordered_resolved_tags
+        except HTTPException:
+            raise
         except Exception as e:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1662,24 +1981,53 @@ class PostService:
             tag_data: TagCreate
     ) -> Tag:
         try:
+            await PostService._validate_category_exists(session, tag_data.category_id)
             if not tag_data.slug or not tag_data.slug.strip():
-                generated_slug = await PostService.generate_unique_slug(session, tag_data.name, Tag)
-            else:
-                generated_slug = tag_data.slug.strip()
-                existing_tag = await session.execute(
-                    select(Tag)
-                    .where((Tag.name == tag_data.name) | (Tag.slug == tag_data.slug))
+                generated_slug = await PostService.generate_unique_taxonomy_slug(
+                    session,
+                    tag_data.name,
+                    Tag,
+                    TagSlugHistory,
+                    max_length=PostService.TAG_SLUG_MAX_LENGTH,
                 )
-                if existing_tag.scalar_one_or_none():
+            else:
+                generated_slug = PostService.normalize_taxonomy_slug(
+                    tag_data.slug,
+                    max_length=PostService.TAG_SLUG_MAX_LENGTH,
+                )
+                existing_tag = await session.execute(
+                    select(Tag.id).where(Tag.name == tag_data.name)
+                )
+                if existing_tag.scalar_one_or_none() or await PostService._slug_in_use(
+                    session, Tag, TagSlugHistory, generated_slug
+                ):
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
                         detail="Tag with this name or slug already exists"
                     )
 
+            canonical_tag_id = tag_data.canonical_tag_id
+            if canonical_tag_id is not None:
+                canonical_result = await session.execute(
+                    select(Tag).where(
+                        Tag.id == canonical_tag_id,
+                        Tag.is_active.is_(True),
+                        Tag.canonical_tag_id.is_(None),
+                    )
+                )
+                if canonical_result.scalar_one_or_none() is None:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail="Canonical replacement tag not found",
+                    )
+            is_active = tag_data.is_active if tag_data.is_active is not None else canonical_tag_id is None
+
             db_tag = Tag(
                 name=tag_data.name,
                 slug=generated_slug,
-                category_id=tag_data.category_id
+                category_id=tag_data.category_id,
+                is_active=is_active if canonical_tag_id is None else False,
+                canonical_tag_id=canonical_tag_id,
             )
 
             session.add(db_tag)
@@ -1693,6 +2041,137 @@ class PostService:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Failed to create tag: {str(e)}"
+            )
+
+    @staticmethod
+    async def update_tag(
+            session: AsyncSession,
+            tag_id: int,
+            tag_data: TagUpdate
+    ) -> Tag:
+        try:
+            result = await session.execute(select(Tag).where(Tag.id == tag_id))
+            db_tag = result.scalar_one_or_none()
+            if not db_tag:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Tag not found",
+                )
+
+            if tag_data.name is not None:
+                existing_name = await session.execute(
+                    select(Tag.id).where(Tag.name == tag_data.name, Tag.id != tag_id)
+                )
+                if existing_name.scalar_one_or_none() is not None:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Tag with this name already exists",
+                    )
+                db_tag.name = tag_data.name
+
+            if tag_data.category_id is not None:
+                await PostService._validate_category_exists(session, tag_data.category_id)
+                db_tag.category_id = tag_data.category_id
+
+            if tag_data.slug is not None and tag_data.slug.strip():
+                normalized_slug = PostService.normalize_taxonomy_slug(
+                    tag_data.slug,
+                    max_length=PostService.TAG_SLUG_MAX_LENGTH,
+                )
+                if await PostService._slug_in_use(
+                    session, Tag, TagSlugHistory, normalized_slug, exclude_id=tag_id
+                ):
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Tag with this slug already exists",
+                    )
+                if normalized_slug != db_tag.slug:
+                    await PostService._record_slug_history(
+                        session,
+                        history_model=TagSlugHistory,
+                        owner_id=db_tag.id,
+                        slug=db_tag.slug,
+                    )
+                    db_tag.slug = normalized_slug
+
+            if "canonical_tag_id" in tag_data.model_fields_set:
+                canonical_tag_id = tag_data.canonical_tag_id
+                if canonical_tag_id == tag_id:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="A tag cannot point to itself as canonical",
+                    )
+                if canonical_tag_id is None:
+                    db_tag.canonical_tag_id = None
+                else:
+                    canonical_result = await session.execute(
+                        select(Tag).where(
+                            Tag.id == canonical_tag_id,
+                            Tag.is_active.is_(True),
+                            Tag.canonical_tag_id.is_(None),
+                        )
+                    )
+                    if canonical_result.scalar_one_or_none() is None:
+                        raise HTTPException(
+                            status_code=status.HTTP_404_NOT_FOUND,
+                            detail="Canonical replacement tag not found",
+                        )
+                    db_tag.canonical_tag_id = canonical_tag_id
+                    db_tag.is_active = False
+
+            if "is_active" in tag_data.model_fields_set and tag_data.is_active is not None:
+                if db_tag.canonical_tag_id is not None and tag_data.is_active:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Deprecated tags cannot remain active",
+                    )
+                db_tag.is_active = tag_data.is_active
+
+            await session.commit()
+            await session.refresh(db_tag)
+            return db_tag
+        except HTTPException:
+            raise
+        except Exception as e:
+            await session.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to update tag: {str(e)}"
+            )
+
+    @staticmethod
+    async def delete_tag(
+            session: AsyncSession,
+            tag_id: int
+    ) -> None:
+        try:
+            result = await session.execute(
+                select(Tag)
+                .where(Tag.id == tag_id)
+                .options(selectinload(Tag.posts))
+            )
+            db_tag = result.scalar_one_or_none()
+            if not db_tag:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Tag not found",
+                )
+
+            if db_tag.posts:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Cannot delete a tag that is still attached to posts. Deprecate it instead.",
+                )
+
+            await session.delete(db_tag)
+            await session.commit()
+        except HTTPException:
+            raise
+        except Exception as e:
+            await session.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to delete tag: {str(e)}"
             )
 
     @staticmethod

--- a/api/tests/test_ai_router.py
+++ b/api/tests/test_ai_router.py
@@ -5,6 +5,7 @@ from httpx import ASGITransport, AsyncClient
 from routers.v1.ai import router as ai_router
 from services.ai.generator import AIGeneratorService
 from services.ai.blog_agent import BlogAgentService
+from services.ai.taxonomy import BlogTaxonomyService
 from services.post import PostService
 from services.user.auth import get_current_active_user
 from database.connection import get_db_session
@@ -121,7 +122,13 @@ async def test_generate_excerpt_ok(app, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_generate_blog_ok_without_save_or_publish(app, monkeypatch):
-    from schemas.ai import BlogPost, BlogSection
+    from schemas.ai import (
+        BlogPost,
+        BlogSection,
+        BlogTaxonomyCategory,
+        BlogTaxonomySuggestion,
+        BlogTaxonomyTag,
+    )
 
     async def fake_blog_generate(self, **kwargs):
         post = BlogPost(
@@ -161,7 +168,27 @@ async def test_generate_blog_ok_without_save_or_publish(app, monkeypatch):
         )
         return post, 0.12, False, None
 
+    async def fake_taxonomy_suggestion(*args, **kwargs):
+        return BlogTaxonomySuggestion(
+            category=BlogTaxonomyCategory(
+                id=45,
+                name="Artificial Intelligence",
+                slug="artificial-intelligence",
+                parent_id=44,
+            ),
+            tags=[
+                BlogTaxonomyTag(id=101, name="AI", slug="ai", category_id=45),
+                BlogTaxonomyTag(id=104, name="LLMs", slug="llms", category_id=45),
+            ],
+        )
+
     monkeypatch.setattr(BlogAgentService, "generate", fake_blog_generate, raising=True)
+    monkeypatch.setattr(
+        BlogTaxonomyService,
+        "suggest_for_generated_post",
+        fake_taxonomy_suggestion,
+        raising=True,
+    )
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
@@ -183,6 +210,80 @@ async def test_generate_blog_ok_without_save_or_publish(app, monkeypatch):
         assert "passed" in data["quality_report"]
         assert "readability" in data["quality_report"]
         assert "phase_metrics" in data["quality_report"]
+        assert data["resolved_keywords"][:2] == ["AI Writer", "Pydantic AI"]
+        assert data["taxonomy_suggestion"]["category"]["id"] == 45
+        assert [tag["id"] for tag in data["taxonomy_suggestion"]["tags"]] == [101, 104]
+
+
+@pytest.mark.asyncio
+async def test_generate_blog_auto_generates_keywords_when_blank(app, monkeypatch):
+    from schemas.ai import (
+        BlogPost,
+        BlogSection,
+        BlogTaxonomyCategory,
+        BlogTaxonomySuggestion,
+        BlogTaxonomyTag,
+    )
+
+    async def fake_blog_generate(self, **kwargs):
+        post = BlogPost(
+            title="OpenAI and Anthropic IPO Rumors and AI Valuation Signals",
+            slug="openai-and-anthropic-ipo-rumors-and-ai-valuation-signals",
+            summary=(
+                "A grounded news analysis of what IPO rumors can signal for "
+                "venture sentiment, startup multiples, and public-market "
+                "expectations around artificial intelligence companies."
+            ),
+            sections=[
+                BlogSection(heading="Headline Context", body_markdown=" ".join(["word"] * 200)),
+                BlogSection(heading="Market Signals", body_markdown=" ".join(["word"] * 210)),
+                BlogSection(heading="Investor Readthrough", body_markdown=" ".join(["word"] * 220)),
+            ],
+            tags=["startup-valuations", "ai-investing", "ipo-rumors"],
+            seo_title="What OpenAI and Anthropic IPO Rumors Signal for AI Valuations",
+            seo_description=(
+                "Understand how OpenAI and Anthropic IPO rumors can affect "
+                "investor confidence, startup valuation narratives, and "
+                "artificial intelligence market sentiment."
+            ),
+        )
+        return post, 0.2, True, [{"title": "Source", "url": "https://example.com"}]
+
+    async def fake_taxonomy_suggestion(*args, **kwargs):
+        return BlogTaxonomySuggestion(
+            category=BlogTaxonomyCategory(
+                id=53,
+                name="Creator Business",
+                slug="creator-economy-and-monetization",
+                parent_id=50,
+            ),
+            tags=[
+                BlogTaxonomyTag(id=150, name="Artificial Intelligence", slug="artificial-intelligence", category_id=45),
+                BlogTaxonomyTag(id=151, name="Startup Valuations", slug="startup-valuations", category_id=51),
+            ],
+        )
+
+    monkeypatch.setattr(BlogAgentService, "generate", fake_blog_generate, raising=True)
+    monkeypatch.setattr(
+        BlogTaxonomyService,
+        "suggest_for_generated_post",
+        fake_taxonomy_suggestion,
+        raising=True,
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        payload = {
+            "topic": "What OpenAI and Anthropic IPO rumors mean for investor confidence in artificial intelligence startup valuations today.",
+            "save_draft": False,
+            "publish_post": False,
+        }
+        resp = await ac.post("/v1/ai/generate/blog", json=payload)
+
+    assert resp.status_code == status.HTTP_200_OK
+    data = resp.json()
+    assert data["resolved_keywords"]
+    assert "Artificial Intelligence" in data["resolved_keywords"]
 
 
 @pytest.mark.asyncio
@@ -194,6 +295,7 @@ async def test_get_blog_options_exposes_web_search_default(app):
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["use_web_search_default"] is True
+    assert data["blog_types"][0]["value"] == "news"
 
 
 @pytest.mark.asyncio
@@ -218,7 +320,13 @@ async def test_generate_blog_quality_error_returns_400(app, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_generate_blog_publish_persists_quality_metadata(app, monkeypatch):
-    from schemas.ai import BlogPost, BlogSection
+    from schemas.ai import (
+        BlogPost,
+        BlogSection,
+        BlogTaxonomyCategory,
+        BlogTaxonomySuggestion,
+        BlogTaxonomyTag,
+    )
 
     async def fake_blog_generate(self, **kwargs):
         post = BlogPost(
@@ -245,11 +353,31 @@ async def test_generate_blog_publish_persists_quality_metadata(app, monkeypatch)
         )
         return post, 0.33, True, [{"title": "Source", "url": "https://example.com"}]
 
+    async def fake_taxonomy_suggestion(*args, **kwargs):
+        return BlogTaxonomySuggestion(
+            category=BlogTaxonomyCategory(
+                id=45,
+                name="Artificial Intelligence",
+                slug="artificial-intelligence",
+                parent_id=44,
+            ),
+            tags=[
+                BlogTaxonomyTag(id=101, name="AI", slug="ai", category_id=45),
+                BlogTaxonomyTag(id=104, name="LLMs", slug="llms", category_id=45),
+            ],
+        )
+
     monkeypatch.setattr(BlogAgentService, "generate", fake_blog_generate, raising=True)
     monkeypatch.setattr(
         BlogAgentService,
         "blog_post_to_html",
         lambda self, blog_post: "<p>stub html</p>",
+        raising=True,
+    )
+    monkeypatch.setattr(
+        BlogTaxonomyService,
+        "suggest_for_generated_post",
+        fake_taxonomy_suggestion,
         raising=True,
     )
 
@@ -285,5 +413,9 @@ async def test_generate_blog_publish_persists_quality_metadata(app, monkeypatch)
     persisted = captured["post_data"].content_blocks
     assert "ai_generation" in persisted
     assert persisted["ai_generation"]["generator"] == "blog-agent"
+    assert persisted["ai_generation"]["resolved_keywords"][:2] == ["AI Pipeline", "Quality Metrics"]
     assert "quality_report" in persisted["ai_generation"]
     assert "phase_metrics" in persisted["ai_generation"]
+    assert persisted["ai_generation"]["taxonomy_suggestion"]["category"]["id"] == 45
+    assert captured["post_data"].category_id == 45
+    assert captured["post_data"].tag_ids == [101, 104]

--- a/api/tests/test_ai_taxonomy.py
+++ b/api/tests/test_ai_taxonomy.py
@@ -1,0 +1,126 @@
+from models import Category, Tag
+from schemas.ai import BlogPost, BlogSection
+from services.ai.taxonomy import BlogTaxonomyService, _TaxonomyResolver
+
+
+def _build_post(*, title: str, summary: str, tags: list[str]) -> BlogPost:
+    return BlogPost(
+        title=title,
+        slug="test-post-slug",
+        summary=summary,
+        sections=[
+            BlogSection(
+                heading="Section One",
+                body_markdown=" ".join(["word"] * 80),
+            ),
+            BlogSection(
+                heading="Section Two",
+                body_markdown=" ".join(["word"] * 80),
+            ),
+            BlogSection(
+                heading="Section Three",
+                body_markdown=" ".join(["word"] * 80),
+            ),
+        ],
+        tags=tags,
+        seo_title="Test SEO Title That Fits The Length",
+        seo_description=(
+            "A suitable SEO description that is long enough to satisfy the "
+            "schema without affecting taxonomy scoring."
+        ),
+    )
+
+
+def test_taxonomy_resolver_returns_confident_match_for_clear_signals():
+    tech = Category(id=1, name="Tech & Innovation", slug="tech-and-innovation", parent_id=None)
+    automation = Category(id=2, name="Automation", slug="automation", parent_id=1)
+    business = Category(id=3, name="Business & Finance", slug="business-and-finance", parent_id=None)
+
+    automation_tag = Tag(id=10, name="Automation", slug="automation", category_id=2, is_active=True)
+    workflow_tag = Tag(
+        id=11,
+        name="Workflow Automation",
+        slug="workflow-automation",
+        category_id=2,
+        is_active=True,
+    )
+    finance_tag = Tag(id=12, name="Investing", slug="investing", category_id=3, is_active=True)
+
+    resolver = _TaxonomyResolver(
+        categories=[tech, automation, business],
+        tags=[automation_tag, workflow_tag, finance_tag],
+    )
+
+    result = resolver.resolve(
+        topic="Workflow automation for enterprise operations teams",
+        blog_post=_build_post(
+            title="Workflow Automation Playbook for Fast-Moving Teams",
+            summary="A practical guide to automation systems, workflow design, and process automation.",
+            tags=["automation", "workflow automation"],
+        ),
+        keywords=["workflow automation", "process automation"],
+        preferred_category_id=None,
+    )
+
+    assert result.category is not None
+    assert result.category.id == 2
+    assert result.review_required is False
+    assert result.confidence_score >= BlogTaxonomyService.LOW_CONFIDENCE_THRESHOLD
+    assert [tag.name for tag in result.tags] == ["Workflow Automation", "Automation"]
+
+
+def test_taxonomy_resolver_returns_review_required_when_signals_are_weak():
+    tech = Category(id=1, name="Tech & Innovation", slug="tech-and-innovation", parent_id=None)
+    automation = Category(id=2, name="Automation", slug="automation", parent_id=1)
+    business = Category(id=3, name="Business & Finance", slug="business-and-finance", parent_id=None)
+    marketing = Category(id=4, name="Online Business & Marketing", slug="online-business-and-marketing", parent_id=3)
+
+    automation_tag = Tag(id=10, name="Automation", slug="automation", category_id=2, is_active=True)
+    marketing_tag = Tag(id=11, name="Affiliate Marketing", slug="affiliate-marketing", category_id=4, is_active=True)
+
+    resolver = _TaxonomyResolver(
+        categories=[tech, automation, business, marketing],
+        tags=[automation_tag, marketing_tag],
+    )
+
+    result = resolver.resolve(
+        topic="Fresh perspectives for modern teams",
+        blog_post=_build_post(
+            title="Fresh perspectives for modern teams",
+            summary="A broad reflection on change, decision making, and current ideas.",
+            tags=["insights", "trends"],
+        ),
+        keywords=["ideas"],
+        preferred_category_id=None,
+    )
+
+    assert result.category is None
+    assert result.tags == []
+    assert result.review_required is True
+    assert result.confidence_score < BlogTaxonomyService.LOW_CONFIDENCE_THRESHOLD
+
+
+def test_taxonomy_resolver_keeps_preferred_category_even_when_review_is_required():
+    tech = Category(id=1, name="Tech & Innovation", slug="tech-and-innovation", parent_id=None)
+    products = Category(id=2, name="Products & Platforms", slug="products-and-platforms", parent_id=1)
+    products_tag = Tag(id=10, name="Creator Platforms", slug="creator-platforms", category_id=2, is_active=True)
+
+    resolver = _TaxonomyResolver(
+        categories=[tech, products],
+        tags=[products_tag],
+    )
+
+    result = resolver.resolve(
+        topic="A broad update",
+        blog_post=_build_post(
+            title="A broad update",
+            summary="A short general piece with weak taxonomy signals and very little specific taxonomy evidence.",
+            tags=["update", "general"],
+        ),
+        keywords=[],
+        preferred_category_id=2,
+    )
+
+    assert result.category is not None
+    assert result.category.id == 2
+    assert result.review_required is True

--- a/api/tests/test_post_taxonomy_metadata.py
+++ b/api/tests/test_post_taxonomy_metadata.py
@@ -1,0 +1,304 @@
+import pytest
+
+
+VALID_EXCERPT = (
+    "A publish-ready summary that captures the core article, explains why it "
+    "matters now, and gives readers a clear reason to keep reading."
+)
+
+
+async def _create_category(client_admin, *, name: str, slug: str, parent_id=None):
+    payload = {"name": name, "slug": slug}
+    if parent_id is not None:
+        payload["parent_id"] = parent_id
+    response = await client_admin.post("/v1/posts/categories/", json=payload)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+async def _create_tag(
+    client_admin,
+    *,
+    name: str,
+    slug: str,
+    category_id=None,
+    is_active=True,
+    canonical_tag_id=None,
+):
+    payload = {
+        "name": name,
+        "slug": slug,
+        "category_id": category_id,
+        "is_active": is_active,
+        "canonical_tag_id": canonical_tag_id,
+    }
+    response = await client_admin.post("/v1/posts/tags/", json=payload)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+@pytest.mark.asyncio
+async def test_post_seo_keywords_round_trip_create_and_update(client_admin, client_author):
+    category = await _create_category(client_admin, name="Tech Tests", slug="tech-tests")
+    tag = await _create_tag(
+        client_admin,
+        name="Automation",
+        slug="automation",
+        category_id=category["id"],
+    )
+
+    create_response = await client_author.post(
+        "/v1/posts/",
+        data={
+            "title": "SEO Metadata Draft",
+            "content": "<p>Hello metadata</p>",
+            "excerpt": VALID_EXCERPT,
+            "category_id": str(category["id"]),
+            "tag_ids": str(tag["id"]),
+            "seo_keywords": "automation, workflows, automation",
+            "is_published": "true",
+        },
+    )
+    assert create_response.status_code == 201, create_response.text
+    created = create_response.json()
+    assert created["seo_keywords"] == ["automation", "workflows"]
+
+    update_response = await client_author.put(
+        f"/v1/posts/{created['uuid']}",
+        data={
+            "seo_keywords": "product launch, automation",
+            "is_published": "true",
+        },
+    )
+    assert update_response.status_code == 200, update_response.text
+    updated = update_response.json()
+    assert updated["seo_keywords"] == ["product launch", "automation"]
+
+
+@pytest.mark.asyncio
+async def test_deprecated_tags_are_hidden_and_resolve_to_canonical_tag_on_save(
+    client_admin,
+    client_author,
+):
+    category = await _create_category(client_admin, name="Career Tests", slug="career-tests")
+    canonical = await _create_tag(
+        client_admin,
+        name="Freelancing",
+        slug="freelancing",
+        category_id=category["id"],
+    )
+    deprecated = await _create_tag(
+        client_admin,
+        name="Upwork",
+        slug="upwork",
+        category_id=category["id"],
+        is_active=False,
+        canonical_tag_id=canonical["id"],
+    )
+
+    list_response = await client_author.get("/v1/posts/tags/")
+    assert list_response.status_code == 200, list_response.text
+    tag_names = {tag["name"] for tag in list_response.json()["tags"]}
+    assert "Freelancing" in tag_names
+    assert "Upwork" not in tag_names
+
+    create_response = await client_author.post(
+        "/v1/posts/",
+        data={
+            "title": "Legacy Tag Draft",
+            "content": "<p>Trying to use a deprecated tag.</p>",
+            "excerpt": VALID_EXCERPT,
+            "tag_ids": f"{deprecated['id']},{canonical['id']}",
+            "is_published": "true",
+        },
+    )
+    assert create_response.status_code == 201, create_response.text
+    created = create_response.json()
+    assert [tag["name"] for tag in created["tags"]] == ["Freelancing"]
+
+
+@pytest.mark.asyncio
+async def test_inactive_tags_without_canonical_replacement_are_rejected(client_admin, client_author):
+    category = await _create_category(client_admin, name="Rejected Tags", slug="rejected-tags")
+    inactive = await _create_tag(
+        client_admin,
+        name="Legacy Platform",
+        slug="legacy-platform",
+        category_id=category["id"],
+        is_active=False,
+    )
+
+    create_response = await client_author.post(
+        "/v1/posts/",
+        data={
+            "title": "Unavailable Tag Draft",
+            "content": "<p>Trying to use an inactive tag without a replacement.</p>",
+            "excerpt": VALID_EXCERPT,
+            "tag_ids": str(inactive["id"]),
+            "is_published": "true",
+        },
+    )
+    assert create_response.status_code == 400, create_response.text
+    assert create_response.json()["detail"] == "One or more selected tags are unavailable"
+
+
+@pytest.mark.asyncio
+async def test_tags_must_belong_to_selected_category_branch(client_admin, client_author):
+    tech = await _create_category(client_admin, name="Tech Root", slug="tech-root")
+    products = await _create_category(
+        client_admin,
+        name="Products & Platforms",
+        slug="products-and-platforms",
+        parent_id=tech["id"],
+    )
+    security = await _create_category(
+        client_admin,
+        name="Cybersecurity & Privacy",
+        slug="cybersecurity-and-privacy",
+        parent_id=tech["id"],
+    )
+    security_tag = await _create_tag(
+        client_admin,
+        name="Cybersecurity",
+        slug="cybersecurity",
+        category_id=security["id"],
+    )
+
+    create_response = await client_author.post(
+        "/v1/posts/",
+        data={
+            "title": "Mismatched Taxonomy Draft",
+            "content": "<p>Trying to mix sibling taxonomy branches.</p>",
+            "excerpt": VALID_EXCERPT,
+            "category_id": str(products["id"]),
+            "tag_ids": str(security_tag["id"]),
+            "is_published": "true",
+        },
+    )
+    assert create_response.status_code == 400, create_response.text
+    assert create_response.json()["detail"] == "Selected tags must belong to the chosen category branch"
+
+
+@pytest.mark.asyncio
+async def test_parent_category_accepts_descendant_branch_tags(client_admin, client_author):
+    tech = await _create_category(client_admin, name="Tech Parent", slug="tech-parent")
+    automation = await _create_category(
+        client_admin,
+        name="Automation",
+        slug="automation",
+        parent_id=tech["id"],
+    )
+    automation_tag = await _create_tag(
+        client_admin,
+        name="Workflow Automation",
+        slug="workflow-automation",
+        category_id=automation["id"],
+    )
+
+    create_response = await client_author.post(
+        "/v1/posts/",
+        data={
+            "title": "Parent Branch Draft",
+            "content": "<p>Parent categories should accept descendant tags.</p>",
+            "excerpt": VALID_EXCERPT,
+            "category_id": str(tech["id"]),
+            "tag_ids": str(automation_tag["id"]),
+            "is_published": "true",
+        },
+    )
+    assert create_response.status_code == 201, create_response.text
+    created = create_response.json()
+    assert created["category"]["id"] == tech["id"]
+    assert [tag["name"] for tag in created["tags"]] == ["Workflow Automation"]
+
+
+@pytest.mark.asyncio
+async def test_category_slug_resolution_supports_legacy_redirects(client_admin, client_public):
+    created = await _create_category(
+        client_admin,
+        name="Products and Platforms",
+        slug="products-platforms",
+    )
+
+    update_response = await client_admin.put(
+        f"/v1/posts/categories/{created['id']}",
+        json={"slug": "products-and-platforms"},
+    )
+    assert update_response.status_code == 200, update_response.text
+
+    legacy_response = await client_public.get(
+        "/v1/posts/categories/resolve/products-platforms"
+    )
+    assert legacy_response.status_code == 200, legacy_response.text
+    legacy_payload = legacy_response.json()
+    assert legacy_payload["matched_slug"] == "products-platforms"
+    assert legacy_payload["canonical_slug"] == "products-and-platforms"
+    assert legacy_payload["redirect_required"] is True
+
+    canonical_response = await client_public.get(
+        "/v1/posts/categories/resolve/products-and-platforms"
+    )
+    assert canonical_response.status_code == 200, canonical_response.text
+    canonical_payload = canonical_response.json()
+    assert canonical_payload["redirect_required"] is False
+    assert canonical_payload["canonical_slug"] == "products-and-platforms"
+
+
+@pytest.mark.asyncio
+async def test_category_name_update_keeps_existing_slug_until_explicit_slug_change(client_admin):
+    created = await _create_category(
+        client_admin,
+        name="Business Signals",
+        slug="business-signals",
+    )
+
+    rename_response = await client_admin.put(
+        f"/v1/posts/categories/{created['id']}",
+        json={"name": "Business Market Signals"},
+    )
+    assert rename_response.status_code == 200, rename_response.text
+    renamed = rename_response.json()
+    assert renamed["name"] == "Business Market Signals"
+    assert renamed["slug"] == "business-signals"
+
+
+@pytest.mark.asyncio
+async def test_tag_can_be_deprecated_into_canonical_tag_and_hidden_from_default_list(client_admin, client_author):
+    category = await _create_category(
+        client_admin,
+        name="Automation Tests",
+        slug="automation-tests",
+    )
+    canonical = await _create_tag(
+        client_admin,
+        name="Automation",
+        slug="automation",
+        category_id=category["id"],
+    )
+    legacy = await _create_tag(
+        client_admin,
+        name="Zapier",
+        slug="zapier",
+        category_id=category["id"],
+    )
+
+    update_response = await client_admin.put(
+        f"/v1/posts/tags/{legacy['id']}",
+        json={"canonical_tag_id": canonical["id"], "is_active": False},
+    )
+    assert update_response.status_code == 200, update_response.text
+    updated = update_response.json()
+    assert updated["canonical_tag_id"] == canonical["id"]
+    assert updated["is_active"] is False
+
+    public_tags = await client_author.get("/v1/posts/tags/")
+    assert public_tags.status_code == 200, public_tags.text
+    public_names = {tag["name"] for tag in public_tags.json()["tags"]}
+    assert "Automation" in public_names
+    assert "Zapier" not in public_names
+
+    admin_tags = await client_admin.get("/v1/posts/tags/", params={"include_inactive": "true"})
+    assert admin_tags.status_code == 200, admin_tags.text
+    legacy_payload = next(tag for tag in admin_tags.json()["tags"] if tag["id"] == legacy["id"])
+    assert legacy_payload["canonical_tag_id"] == canonical["id"]
+    assert legacy_payload["is_active"] is False

--- a/api/tests/test_posts_publish_flag.py
+++ b/api/tests/test_posts_publish_flag.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import pytest
 from uuid import uuid4
@@ -79,6 +80,35 @@ async def test_update_post_toggle_publish(client_author):
     body2 = resp2.json()
     assert body2["is_published"] is False
     assert body2["published_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_published_post_keeps_original_published_at(client_author):
+    create = await client_author.post("/v1/posts/", data={
+        "title": "Published Post",
+        "content": "<p>Original content</p>",
+        "excerpt": VALID_EXCERPT,
+        "is_published": "true",
+    })
+    assert create.status_code == 201, create.text
+    post = create.json()
+
+    original_published_at = post["published_at"]
+    original_updated_at = post["updated_at"]
+
+    await asyncio.sleep(0.01)
+
+    update = await client_author.put(f"/v1/posts/{post['uuid']}", data={
+        "title": "Published Post Updated",
+        "content": "<p>Updated content</p>",
+        "is_published": "true",
+    })
+    assert update.status_code == 200, update.text
+    body = update.json()
+
+    assert body["is_published"] is True
+    assert body["published_at"] == original_published_at
+    assert body["updated_at"] != original_updated_at
 
 
 @pytest.mark.asyncio

--- a/frontend/e2e/ai-taxonomy-flow.spec.mjs
+++ b/frontend/e2e/ai-taxonomy-flow.spec.mjs
@@ -1,0 +1,290 @@
+import { test, expect } from '@playwright/test';
+
+
+function buildToken() {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({
+      sub: '1',
+      exp: Math.floor(Date.now() / 1000) + 60 * 60,
+    }),
+  ).toString('base64url');
+  return `${header}.${payload}.signature`;
+}
+
+
+function json(route, body, status = 200) {
+  return route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+
+test('admin AI flow auto-fills taxonomy and SEO, preserves publish date, and shows updated date', async ({ page }) => {
+  const token = buildToken();
+  const user = {
+    uuid: 'admin-uuid',
+    email: 'admin@craftyx.com',
+    username: 'admin',
+    full_name: 'CraftyX Admin',
+    role: 'admin',
+    is_active: true,
+    created_at: '2026-04-07T00:00:00Z',
+    updated_at: '2026-04-07T00:00:00Z',
+  };
+
+  const categories = [
+    {
+      id: 44,
+      name: 'Tech & Innovation',
+      slug: 'tech-and-innovation',
+      parent_id: null,
+      subcategories: [
+        { id: 74, name: 'Products & Platforms', slug: 'products-and-platforms' },
+      ],
+    },
+    {
+      id: 50,
+      name: 'Business & Finance',
+      slug: 'business-and-finance',
+      parent_id: null,
+      subcategories: [
+        {
+          id: 75,
+          name: 'Business News & Market Intelligence',
+          slug: 'business-news-and-market-intelligence',
+        },
+      ],
+    },
+  ];
+  const tags = [
+    { id: 301, name: 'AI Agents', slug: 'ai-agents', category_id: 74, created_at: '2026-04-07T00:00:00Z', is_active: true },
+    { id: 302, name: 'Automation', slug: 'automation', category_id: 74, created_at: '2026-04-07T00:00:00Z', is_active: true },
+  ];
+  const generated = {
+    blog_post: {
+      title: 'AI Agents for Enterprise Teams',
+      slug: 'ai-agents-for-enterprise-teams',
+      summary: 'A practical look at how enterprise teams evaluate AI agents, workflow design, and governance before rollout.',
+      sections: [
+        { heading: 'Why Teams Care', body_markdown: 'Enterprise teams need clarity before rollout.' },
+        { heading: 'How Evaluation Works', body_markdown: 'Strong pilots balance capability, control, and measurable outcomes.' },
+        { heading: 'What Leaders Should Watch', body_markdown: 'Security, process design, and change management matter most.' },
+      ],
+      tags: ['ai agents', 'automation'],
+      seo_title: 'Enterprise AI Agents Buying Guide',
+      seo_description: 'See how enterprise teams assess AI agents, workflow automation, and rollout risk before wider adoption.',
+    },
+    resolved_keywords: ['AI Agents', 'Workflow Automation'],
+    taxonomy_suggestion: {
+      category: {
+        id: 74,
+        name: 'Products & Platforms',
+        slug: 'products-and-platforms',
+        parent_id: 44,
+      },
+      tags: [
+        { id: 301, name: 'AI Agents', slug: 'ai-agents', category_id: 74 },
+        { id: 302, name: 'Automation', slug: 'automation', category_id: 74 },
+      ],
+    },
+    draft_id: 'ai-draft-1',
+    post_id: null,
+    model_used: 'claude-sonnet-4.6',
+    generation_time: 0.42,
+    web_search_used: true,
+    search_sources: [{ title: 'Enterprise AI report', url: 'https://example.com/report' }],
+    quality_report: { passed: true, readability: {}, phase_metrics: {} },
+  };
+
+  let storedPost = null;
+  let lastPublishedAt = null;
+
+  await page.route('**/v1/**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+
+    if (path.endsWith('/auth/login') && request.method() === 'POST') {
+      return json(route, { access_token: token, token_type: 'bearer', expires_in: 3600 });
+    }
+
+    if (path.endsWith('/auth/me') && request.method() === 'GET') {
+      return json(route, user);
+    }
+
+    if (path.endsWith('/ai/blog/options') && request.method() === 'GET') {
+      return json(route, {
+        blog_types: [{ value: 'news', label: 'News Article' }],
+        tones: [{ value: 'professional', label: 'Professional' }],
+        audiences: [{ value: 'general', label: 'General Audience' }],
+        lengths: [{ value: 'medium', label: 'Medium (~500 words)' }],
+        models: [{ value: 'claude-sonnet-4.6', label: 'Sonnet 4.6' }],
+        use_web_search_default: true,
+      });
+    }
+
+    if (path.endsWith('/ai/generate/blog') && request.method() === 'POST') {
+      const body = request.postDataJSON();
+      expect(body.blog_type).toBe('news');
+      expect(body.use_web_search).toBe(true);
+      return json(route, generated);
+    }
+
+    if (path.endsWith('/posts/categories/') && request.method() === 'GET') {
+      return json(route, { categories });
+    }
+
+    if (path.includes('/posts/categories/resolve/') && request.method() === 'GET') {
+      return json(route, {
+        ...categories[0].subcategories[0],
+        description: 'Product previews, launches, and platform reviews.',
+        created_at: '2026-04-07T00:00:00Z',
+        post_count: 0,
+        subcategories: [],
+        parent: {
+          id: 44,
+          name: 'Tech & Innovation',
+          slug: 'tech-and-innovation',
+        },
+        is_subcategory: true,
+        matched_slug: 'products-and-platforms',
+        canonical_slug: 'products-and-platforms',
+        redirect_required: false,
+      });
+    }
+
+    if (path.endsWith('/posts/tags/') && request.method() === 'GET') {
+      return json(route, { tags });
+    }
+
+    if (path.endsWith('/posts/') && request.method() === 'POST') {
+      const body = request.postData() ?? '';
+      expect(body).toContain('seo_keywords');
+      expect(body).toContain('AI Agents, Workflow Automation');
+      storedPost = {
+        uuid: 'draft-post-uuid',
+        title: generated.blog_post.title,
+        slug: generated.blog_post.slug,
+        content: '<p>AI-generated draft</p>',
+        content_blocks: null,
+        excerpt: generated.blog_post.summary,
+        featured_image: null,
+        is_published: false,
+        is_featured: false,
+        view_count: 0,
+        reading_time: 3,
+        meta_title: generated.blog_post.seo_title,
+        meta_description: generated.blog_post.seo_description,
+        seo_keywords: generated.resolved_keywords,
+        published_at: null,
+        created_at: '2026-04-07T00:05:00Z',
+        updated_at: '2026-04-07T00:05:00Z',
+        deleted_at: null,
+        is_reviewed: false,
+        review_comments: null,
+        is_flagged: false,
+        author: user,
+        category: generated.taxonomy_suggestion.category,
+        tags: generated.taxonomy_suggestion.tags,
+        comments: [],
+        liked_by: [],
+        bookmarked_by: [],
+      };
+      return json(route, storedPost, 201);
+    }
+
+    if (path.endsWith('/posts/draft-post-uuid') && request.method() === 'GET') {
+      return json(route, storedPost);
+    }
+
+    if (path.endsWith('/posts/draft-post-uuid') && request.method() === 'PUT') {
+      const body = request.postData() ?? '';
+      const shouldPublish = body.includes('is_published') && body.includes('true');
+      const secondEdit = body.includes('AI Agents for Enterprise Teams Updated');
+
+      if (secondEdit) {
+        storedPost = {
+          ...storedPost,
+          title: 'AI Agents for Enterprise Teams Updated',
+        };
+      }
+
+      if (shouldPublish) {
+        lastPublishedAt = lastPublishedAt || '2026-04-07T01:00:00Z';
+        storedPost = {
+          ...storedPost,
+          is_published: true,
+          published_at: lastPublishedAt,
+          updated_at: secondEdit ? '2026-04-07T03:00:00Z' : '2026-04-07T01:00:00Z',
+        };
+      }
+
+      return json(route, storedPost);
+    }
+
+    if (path.endsWith('/posts/ai-agents-for-enterprise-teams') && request.method() === 'GET') {
+      return json(route, {
+        ...storedPost,
+        likes_count: 0,
+      });
+    }
+
+    if (path.endsWith('/posts/ai-agents-for-enterprise-teams/related') && request.method() === 'GET') {
+      return json(route, { posts: [], total: 0, page: 1, size: 12 });
+    }
+
+    if (path.endsWith('/posts/draft-post-uuid/view') && request.method() === 'POST') {
+      return json(route, { counted: true });
+    }
+
+    if (path.endsWith('/posts/') && request.method() === 'GET') {
+      return json(route, { posts: [], total: 0, page: 1, size: 10 });
+    }
+
+    return json(route, {});
+  });
+
+  await page.goto('/auth/login');
+  await page.getByLabel('Email Address').fill('admin@craftyx.com');
+  await page.getByLabel('Password').fill('admin123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await page.waitForURL('**/dashboard');
+
+  await page.goto('/dashboard/posts/create');
+  await expect(page.getByRole('textbox', { name: 'Title', exact: true })).toBeVisible();
+
+  await page.getByRole('button', { name: /ai writer/i }).click();
+  await page.getByPlaceholder('Topic or title idea...').fill('How enterprise AI agents improve internal operations');
+  await expect(page.getByText('News Article')).toBeVisible();
+  await expect(page.getByRole('checkbox', { name: /web search/i })).toBeChecked();
+  await page.getByRole('button', { name: 'Generate Post' }).click();
+
+  await expect(page.getByRole('button', { name: 'Use as Post' })).toBeVisible();
+  await page.getByRole('button', { name: 'Use as Post' }).click();
+  await page.keyboard.press('Escape');
+
+  await expect(page.locator('input[value="AI Agents for Enterprise Teams"]').first()).toBeVisible();
+  await expect(page.getByLabel('SEO Keywords')).toHaveValue('AI Agents, Workflow Automation');
+
+  await page.getByRole('button', { name: 'Save Draft' }).click();
+  await page.waitForURL('**/dashboard/posts');
+
+  await page.goto('/dashboard/posts/edit/draft-post-uuid');
+  await expect(page.locator('input[value="AI Agents for Enterprise Teams"]').first()).toBeVisible();
+  await expect(page.getByLabel('SEO Keywords')).toHaveValue('AI Agents, Workflow Automation');
+
+  await page.getByRole('button', { name: 'Update & Publish' }).click();
+  await page.waitForURL('**/dashboard/posts');
+
+  await page.goto('/dashboard/posts/edit/draft-post-uuid');
+  await page.locator('input[value="AI Agents for Enterprise Teams"]').first().fill('AI Agents for Enterprise Teams Updated');
+  await page.getByRole('button', { name: 'Update & Publish' }).click();
+  await page.waitForURL('**/dashboard/posts');
+
+  await page.goto('/post/ai-agents-for-enterprise-teams');
+  await expect(page.getByText(/^Published /)).toBeVisible();
+  await expect(page.getByText(/^Updated /)).toBeVisible();
+});

--- a/frontend/e2e/category-slug-redirect.spec.mjs
+++ b/frontend/e2e/category-slug-redirect.spec.mjs
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+
+
+function json(route, body, status = 200) {
+  return route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+
+test('legacy category slugs redirect to the canonical slug', async ({ page }) => {
+  await page.route('**/v1/**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+
+    if (path.endsWith('/posts/categories/resolve/tech-products') && request.method() === 'GET') {
+      return json(route, {
+        id: 74,
+        name: 'Products & Platforms',
+        slug: 'products-and-platforms',
+        description: 'Product previews, launches, and platform reviews.',
+        parent_id: 44,
+        created_at: '2026-04-07T00:00:00Z',
+        post_count: 0,
+        subcategories: [],
+        parent: { id: 44, name: 'Tech & Innovation', slug: 'tech-and-innovation' },
+        is_subcategory: true,
+        matched_slug: 'tech-products',
+        canonical_slug: 'products-and-platforms',
+        redirect_required: true,
+      });
+    }
+
+    if (path.endsWith('/posts/categories/resolve/products-and-platforms') && request.method() === 'GET') {
+      return json(route, {
+        id: 74,
+        name: 'Products & Platforms',
+        slug: 'products-and-platforms',
+        description: 'Product previews, launches, and platform reviews.',
+        parent_id: 44,
+        created_at: '2026-04-07T00:00:00Z',
+        post_count: 0,
+        subcategories: [],
+        parent: { id: 44, name: 'Tech & Innovation', slug: 'tech-and-innovation' },
+        is_subcategory: true,
+        matched_slug: 'products-and-platforms',
+        canonical_slug: 'products-and-platforms',
+        redirect_required: false,
+      });
+    }
+
+    if (path.endsWith('/posts/') && request.method() === 'GET') {
+      return json(route, { posts: [], total: 0, page: 1, size: 6 });
+    }
+
+    return json(route, {});
+  });
+
+  await page.goto('/category/tech-products');
+  await page.waitForURL('**/category/products-and-platforms');
+  await expect(page.getByRole('heading', { name: 'Products & Platforms' })).toBeVisible();
+});

--- a/frontend/e2e/production-smoke.spec.mjs
+++ b/frontend/e2e/production-smoke.spec.mjs
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+
+const productionBaseUrl = process.env.PRODUCTION_BASE_URL;
+const productionCategoryPath = process.env.PRODUCTION_CATEGORY_PATH;
+const productionPostPath = process.env.PRODUCTION_POST_PATH;
+const productionLegacyCategoryPath = process.env.PRODUCTION_LEGACY_CATEGORY_PATH;
+const productionCanonicalCategoryPath = process.env.PRODUCTION_CANONICAL_CATEGORY_PATH;
+
+
+test.describe('production smoke', () => {
+  test.skip(
+    !productionBaseUrl,
+    'Set PRODUCTION_BASE_URL (and optional category/post paths) to run read-only production smoke checks.',
+  );
+
+  test('homepage loads read-only', async ({ page }) => {
+    await page.goto(productionBaseUrl, { waitUntil: 'networkidle' });
+    await expect(page).toHaveURL(new RegExp(productionBaseUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  });
+
+  test('category and post pages load read-only when configured', async ({ page }) => {
+    test.skip(!productionCategoryPath || !productionPostPath, 'Set PRODUCTION_CATEGORY_PATH and PRODUCTION_POST_PATH.');
+
+    await page.goto(new URL(productionCategoryPath, productionBaseUrl).toString(), { waitUntil: 'networkidle' });
+    await expect(page).toHaveURL(/category\//);
+
+    await page.goto(new URL(productionPostPath, productionBaseUrl).toString(), { waitUntil: 'networkidle' });
+    await expect(page).toHaveURL(/post\//);
+  });
+
+  test('legacy category slug redirects when configured', async ({ page }) => {
+    test.skip(
+      !productionLegacyCategoryPath || !productionCanonicalCategoryPath,
+      'Set PRODUCTION_LEGACY_CATEGORY_PATH and PRODUCTION_CANONICAL_CATEGORY_PATH.',
+    );
+
+    await page.goto(new URL(productionLegacyCategoryPath, productionBaseUrl).toString(), {
+      waitUntil: 'networkidle',
+    });
+    await expect(page).toHaveURL(new RegExp(`${productionCanonicalCategoryPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`));
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -54,6 +54,7 @@
         "@eslint/compat": "1.3.1",
         "@eslint/eslintrc": "3.3.1",
         "@eslint/js": "9.32.0",
+        "@playwright/test": "^1.53.2",
         "@vitejs/plugin-react": "4.7.0",
         "eslint": "9.32.0",
         "eslint-config-prettier": "10.1.8",
@@ -1761,6 +1762,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -6757,6 +6774,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "test:node": "node --test tests/*.test.mjs",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
     "lint": "eslint \"src/**/*.{js,jsx}\"",
     "lint:fix": "eslint --fix \"src/**/*.{js,jsx}\"",
     "prettier": "prettier --write \"src/**/*.{js,jsx}\""
@@ -60,6 +62,7 @@
     "@eslint/compat": "1.3.1",
     "@eslint/eslintrc": "3.3.1",
     "@eslint/js": "9.32.0",
+    "@playwright/test": "^1.59.1",
     "@vitejs/plugin-react": "4.7.0",
     "eslint": "9.32.0",
     "eslint-config-prettier": "10.1.8",

--- a/frontend/playwright.config.mjs
+++ b/frontend/playwright.config.mjs
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  retries: 0,
+  reporter: [['list']],
+  outputDir: '../output/playwright/test-results',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 4173',
+    cwd: '.',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/frontend/src/api/services/aiService.js
+++ b/frontend/src/api/services/aiService.js
@@ -24,7 +24,7 @@ import { buildBlogGenerationPayload } from './blogGenerationPayload';
  */
 export const generate = async ({
   tool_id,
-  model = 'glm-5',
+  model = 'glm-5-turbo',
   params = {},
   prompt,
   keywords,
@@ -118,13 +118,13 @@ export const getBlogOptions = async () => {
  */
 export const generateBlog = async ({
   topic,
-  blog_type = 'how-to',
+  blog_type = 'news',
   keywords = [],
   audience = null,
   word_count = 'medium',
   tone = 'professional',
   language = 'en-US',
-  model = 'glm-5',
+  model = 'glm-5-turbo',
   creativity = 0.7,
   use_web_search = true,
   save_draft = true,

--- a/frontend/src/api/services/blogGenerationPayload.js
+++ b/frontend/src/api/services/blogGenerationPayload.js
@@ -3,13 +3,13 @@ export const resolveUseWebSearch = (use_web_search = true) =>
 
 export const buildBlogGenerationPayload = ({
   topic,
-  blog_type = 'how-to',
+  blog_type = 'news',
   keywords = [],
   audience = null,
   word_count = 'medium',
   tone = 'professional',
   language = 'en-US',
-  model = 'glm-5',
+  model = 'glm-5-turbo',
   creativity = 0.7,
   use_web_search = true,
   save_draft = true,

--- a/frontend/src/api/services/categoryService.js
+++ b/frontend/src/api/services/categoryService.js
@@ -20,30 +20,14 @@ export const getCategories = async () => {
  * @returns {Promise<object>} Category with parent info if subcategory
  */
 export const getCategoryBySlug = async (slug) => {
-  const { data } = await axiosPublic.get('/posts/categories/');
-  const categories = data.categories || [];
-  
-  // Search parents first
-  const parent = categories.find((c) => c.slug === slug);
-  if (parent) {
-    return { ...parent, parent: null, isSubcategory: false };
+  try {
+    const { data } = await axiosPublic.get(`/posts/categories/resolve/${encodeURIComponent(slug)}`);
+    return data;
+  } catch (error) {
+    const err = new Error(error.response?.data?.detail || 'Category not found');
+    err.status = error.response?.status || 500;
+    throw err;
   }
-  
-  // Then search subcategories
-  for (const c of categories) {
-    const match = (c.subcategories || []).find((s) => s.slug === slug);
-    if (match) {
-      return {
-        ...match,
-        parent: { id: c.id, name: c.name, slug: c.slug },
-        isSubcategory: true,
-      };
-    }
-  }
-  
-  const err = new Error('Category not found');
-  err.status = 404;
-  throw err;
 };
 
 /**

--- a/frontend/src/components/ai-writer/AiWriterPanel.jsx
+++ b/frontend/src/components/ai-writer/AiWriterPanel.jsx
@@ -39,11 +39,11 @@ import { renderBlogPostToHtml } from '@/utils/blogMarkdown';
 
 const FALLBACK_OPTIONS = {
   blog_types: [
+    { value: 'news', label: 'News Article' },
     { value: 'how-to', label: 'How-To Guide' },
     { value: 'listicle', label: 'Listicle' },
     { value: 'tutorial', label: 'Tutorial' },
     { value: 'opinion', label: 'Opinion' },
-    { value: 'news', label: 'News' },
     { value: 'review', label: 'Review' },
     { value: 'comparison', label: 'Comparison' },
     { value: 'case-study', label: 'Case Study' },
@@ -71,6 +71,10 @@ const FALLBACK_OPTIONS = {
   ],
   models: [
     { value: 'claude-sonnet-4.6', label: 'Sonnet 4.6' },
+    { value: 'gpt-5.4', label: 'GPT-5.4' },
+    { value: 'glm-5-turbo', label: 'GLM 5 Turbo' },
+    { value: 'kimi-k2.5', label: 'Kimi K2.5' },
+    { value: 'qwen-3.6-plus', label: 'Qwen 3.6 Plus' },
   ],
   use_web_search_default: true,
 };
@@ -82,7 +86,7 @@ const FALLBACK_OPTIONS = {
 export default function AiWriterPanel({ onInsert, onReplace, onMetadataFill }) {
   const [options, setOptions] = useState(FALLBACK_OPTIONS);
   const [topic, setTopic] = useState('');
-  const [blogType, setBlogType] = useState('how-to');
+  const [blogType, setBlogType] = useState('news');
   const [keywords, setKeywords] = useState('');
   const [audience, setAudience] = useState('general');
   const [tone, setTone] = useState('professional');
@@ -93,6 +97,8 @@ export default function AiWriterPanel({ onInsert, onReplace, onMetadataFill }) {
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState(null);
   const [generatedContent, setGeneratedContent] = useState(null);
+  const [taxonomySuggestion, setTaxonomySuggestion] = useState(null);
+  const [resolvedKeywords, setResolvedKeywords] = useState([]);
   const [generationTime, setGenerationTime] = useState(null);
   const [searchSources, setSearchSources] = useState(null);
   const [showSources, setShowSources] = useState(false);
@@ -118,7 +124,7 @@ export default function AiWriterPanel({ onInsert, onReplace, onMetadataFill }) {
   const handleGenerate = useCallback(async () => {
     if (!topic.trim()) { setError('Enter a topic'); return; }
     try {
-      setGenerating(true); setError(null); setGeneratedContent(null); setSearchSources(null);
+      setGenerating(true); setError(null); setGeneratedContent(null); setTaxonomySuggestion(null); setResolvedKeywords([]); setSearchSources(null);
       const result = await generateBlog({
         topic, blog_type: blogType,
         keywords: keywords.split(',').map(k => k.trim()).filter(k => k),
@@ -127,7 +133,12 @@ export default function AiWriterPanel({ onInsert, onReplace, onMetadataFill }) {
         save_draft: true, publish_post: false,
       });
       setGeneratedContent(result.blog_post);
+      setTaxonomySuggestion(result.taxonomy_suggestion || null);
+      setResolvedKeywords(result.resolved_keywords || []);
       setGenerationTime(result.generation_time);
+      if (Array.isArray(result.resolved_keywords) && result.resolved_keywords.length > 0) {
+        setKeywords(result.resolved_keywords.join(', '));
+      }
       if (result.search_sources) {
         setSearchSources(result.search_sources);
       }
@@ -143,12 +154,20 @@ export default function AiWriterPanel({ onInsert, onReplace, onMetadataFill }) {
 
   const getMetadata = useCallback(() => {
     if (!generatedContent) return null;
-    return {
-      title: generatedContent.title, slug: generatedContent.slug,
-      excerpt: generatedContent.summary, metaTitle: generatedContent.seo_title,
-      metaDescription: generatedContent.seo_description, tags: generatedContent.tags || [],
-    };
-  }, [generatedContent]);
+      return {
+        title: generatedContent.title, slug: generatedContent.slug,
+        excerpt: generatedContent.summary, metaTitle: generatedContent.seo_title,
+        metaDescription: generatedContent.seo_description,
+        seoKeywords: resolvedKeywords,
+        tags: generatedContent.tags || [],
+        categoryId: taxonomySuggestion?.category?.id || null,
+        tagIds: (taxonomySuggestion?.tags || []).map((tag) => tag.id),
+      };
+  }, [generatedContent, resolvedKeywords, taxonomySuggestion]);
+
+  const taxonomyConfidence = typeof taxonomySuggestion?.confidence_score === 'number'
+    ? Math.round(taxonomySuggestion.confidence_score * 100)
+    : null;
 
   const handleInsert = useCallback(() => {
     if (onInsert && generatedContent) {
@@ -240,7 +259,7 @@ export default function AiWriterPanel({ onInsert, onReplace, onMetadataFill }) {
 
             {/* Keywords */}
             <TextField
-              placeholder="SEO keywords (comma-separated)"
+              placeholder="SEO keywords (auto-generate if blank)"
               fullWidth size="small"
               value={keywords}
               onChange={(e) => setKeywords(e.target.value)}
@@ -322,6 +341,23 @@ export default function AiWriterPanel({ onInsert, onReplace, onMetadataFill }) {
                     sx={{ mr: 0.5, mb: 0.5, height: 20, fontSize: 11, '& .MuiChip-label': { px: 1 } }}
                   />
                 ))}
+              </Box>
+            )}
+
+            {taxonomySuggestion?.category && (
+              <Box sx={{ mb: 1 }}>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                  Suggested category: {taxonomySuggestion.category.name}
+                </Typography>
+                {taxonomyConfidence !== null && (
+                  <Typography
+                    variant="caption"
+                    color={taxonomySuggestion.review_required ? 'warning.main' : 'text.secondary'}
+                    sx={{ display: 'block', fontSize: 11 }}
+                  >
+                    Taxonomy confidence: {taxonomyConfidence}%{taxonomySuggestion.review_required ? ' • review suggested' : ''}
+                  </Typography>
+                )}
               </Box>
             )}
 

--- a/frontend/src/components/editor/PostSettingsSidebar.jsx
+++ b/frontend/src/components/editor/PostSettingsSidebar.jsx
@@ -42,6 +42,7 @@ const DRAWER_WIDTH = 360;
  * @param {function} props.onTagToggle - Tag toggle handler
  * @param {string} props.metaTitle - SEO title
  * @param {string} props.metaDescription - SEO description
+ * @param {string} props.seoKeywords - SEO keywords CSV
  * @param {number} props.readingTime - Reading time in minutes
  * @param {function} props.onMetaChange - Meta change handler
  * @param {boolean} props.categoriesLoading - Loading categories
@@ -63,6 +64,7 @@ const PostSettingsSidebar = ({
   onTagToggle,
   metaTitle = '',
   metaDescription = '',
+  seoKeywords = '',
   readingTime = 1,
   onMetaChange,
   categoriesLoading = false,
@@ -264,6 +266,15 @@ const PostSettingsSidebar = ({
                 helperText={`${metaDescription.length}/155 characters. Keep it specific and social-ready.`}
                 inputProps={{ maxLength: 155 }}
               />
+              <TextField
+                label="SEO Keywords"
+                size="small"
+                fullWidth
+                value={seoKeywords}
+                onChange={(e) => onMetaChange?.({ seoKeywords: e.target.value })}
+                placeholder="AI-generated if blank, comma-separated"
+                helperText="Use short search phrases separated by commas."
+              />
             </Stack>
           </Box>
         </Stack>
@@ -295,6 +306,7 @@ PostSettingsSidebar.propTypes = {
   onTagToggle: PropTypes.func,
   metaTitle: PropTypes.string,
   metaDescription: PropTypes.string,
+  seoKeywords: PropTypes.string,
   readingTime: PropTypes.number,
   onMetaChange: PropTypes.func,
   categoriesLoading: PropTypes.bool,

--- a/frontend/src/views/dashboard/Posts/AdminPostEditor.jsx
+++ b/frontend/src/views/dashboard/Posts/AdminPostEditor.jsx
@@ -111,6 +111,9 @@ export default function AdminPostEditor() {
   const [selectedTags, setSelectedTags] = useState([]);
   const [metaTitle, setMetaTitle] = useState(aiState?.metaTitle || '');
   const [metaDescription, setMetaDescription] = useState(aiState?.metaDescription || '');
+  const [seoKeywords, setSeoKeywords] = useState(
+    Array.isArray(aiState?.seoKeywords) ? aiState.seoKeywords.join(', ') : (aiState?.seoKeywords || '')
+  );
   const [featuredImage, setFeaturedImage] = useState(null);
   const [featuredImagePath, setFeaturedImagePath] = useState(null);
   const [imagePreview, setImagePreview] = useState(null);
@@ -176,6 +179,7 @@ export default function AdminPostEditor() {
           setSelectedTags(post.tags?.map(t => t.id) || []);
           setMetaTitle(post.meta_title || '');
           setMetaDescription(post.meta_description || '');
+          setSeoKeywords(Array.isArray(post.seo_keywords) ? post.seo_keywords.join(', ') : '');
           
           if (post.featured_image) {
             setImagePreview(getImageUrl(post.featured_image));
@@ -267,14 +271,23 @@ export default function AdminPostEditor() {
   const handleAiMetadataFill = useCallback((metadata) => {
     if (!metadata) return;
 
-    if (metadata.title) setTitle(metadata.title);
-    if (metadata.slug) setSlug(metadata.slug);
-    if (metadata.excerpt) {
+    if (metadata.title && !title.trim()) setTitle(metadata.title);
+    if (metadata.slug && !slug.trim()) setSlug(metadata.slug);
+    if (metadata.excerpt && !excerpt.trim()) {
       setExcerpt(metadata.excerpt);
       setExcerptError('');
     }
-    if (metadata.metaTitle) setMetaTitle(metadata.metaTitle);
-    if (metadata.metaDescription) setMetaDescription(metadata.metaDescription);
+    if (metadata.metaTitle && !metaTitle.trim()) setMetaTitle(metadata.metaTitle);
+    if (metadata.metaDescription && !metaDescription.trim()) setMetaDescription(metadata.metaDescription);
+    if (metadata.seoKeywords?.length > 0 && !seoKeywords.trim()) {
+      setSeoKeywords(metadata.seoKeywords.join(', '));
+    }
+    if (metadata.categoryId && !categoryId) setCategoryId(String(metadata.categoryId));
+
+    if (metadata.tagIds?.length > 0 && selectedTags.length === 0) {
+      setSelectedTags(metadata.tagIds);
+      return;
+    }
 
     // Auto-match AI-generated tag names against loaded tags
     if (metadata.tags?.length > 0 && tags.length > 0) {
@@ -283,11 +296,11 @@ export default function AdminPostEditor() {
           aiTag => t.name.toLowerCase() === aiTag.toLowerCase()
         ))
         .map(t => t.id);
-      if (matchedTagIds.length > 0) {
+      if (matchedTagIds.length > 0 && selectedTags.length === 0) {
         setSelectedTags(matchedTagIds);
       }
     }
-  }, [tags]);
+  }, [categoryId, excerpt, metaDescription, metaTitle, selectedTags.length, seoKeywords, slug, tags, title]);
 
   const handleGenerateExcerpt = useCallback(async () => {
     const currentContent = editorRef.current ? editorRef.current.getContent() : content;
@@ -353,6 +366,7 @@ export default function AdminPostEditor() {
       formData.append('excerpt', normalizeExcerpt(excerpt));
       formData.append('meta_title', metaTitle || '');
       formData.append('meta_description', metaDescription || '');
+      formData.append('seo_keywords', seoKeywords || '');
       formData.append('is_published', shouldPublish ? 'true' : 'false');
       
       if (categoryId) {
@@ -619,6 +633,17 @@ export default function AdminPostEditor() {
                       placeholder="Why the article matters, in one tight teaser"
                       helperText={`${metaDescription.length}/155 characters. Keep it specific and social-ready.`}
                       inputProps={{ maxLength: 155 }}
+                    />
+                  </Grid>
+                  <Grid item xs={12}>
+                    <TextField
+                      label="SEO Keywords"
+                      fullWidth
+                      size="small"
+                      value={seoKeywords}
+                      onChange={(e) => setSeoKeywords(e.target.value)}
+                      placeholder="AI-generated if blank, comma-separated"
+                      helperText="Use short search phrases separated by commas."
                     />
                   </Grid>
                 </Grid>

--- a/frontend/src/views/dashboard/Posts/UserPostEditor.jsx
+++ b/frontend/src/views/dashboard/Posts/UserPostEditor.jsx
@@ -75,6 +75,9 @@ export default function UserPostEditor() {
   const [selectedTags, setSelectedTags] = useState([]);
   const [metaTitle, setMetaTitle] = useState(aiState?.metaTitle || '');
   const [metaDescription, setMetaDescription] = useState(aiState?.metaDescription || '');
+  const [seoKeywords, setSeoKeywords] = useState(
+    Array.isArray(aiState?.seoKeywords) ? aiState.seoKeywords.join(', ') : (aiState?.seoKeywords || '')
+  );
   const [customReadingTime, setCustomReadingTime] = useState(null);
 
   // Auto-save state
@@ -153,6 +156,7 @@ export default function UserPostEditor() {
           setSelectedTags(post.tags?.map(t => t.id) || []);
           setMetaTitle(post.meta_title || '');
           setMetaDescription(post.meta_description || '');
+          setSeoKeywords(Array.isArray(post.seo_keywords) ? post.seo_keywords.join(', ') : '');
           setCustomReadingTime(post.reading_time || null);
           
           if (post.featured_image) {
@@ -185,6 +189,7 @@ export default function UserPostEditor() {
       formData.append('excerpt', normalizeExcerpt(manualExcerpt));
       formData.append('meta_title', metaTitle || '');
       formData.append('meta_description', metaDescription || '');
+      formData.append('seo_keywords', seoKeywords || '');
       formData.append(
         'reading_time',
         String(customReadingTime || calculateReadingTime(calculateWordCount(contentData.blocks))),
@@ -210,7 +215,7 @@ export default function UserPostEditor() {
       console.error('Auto-save failed:', err);
       setSaveStatus('error');
     }
-  }, [manualExcerpt, metaTitle, metaDescription, customReadingTime, categoryId, selectedTags]);
+  }, [manualExcerpt, metaTitle, metaDescription, seoKeywords, customReadingTime, categoryId, selectedTags]);
 
   // Handle editor changes
   const handleEditorChange = useCallback((contentData) => {
@@ -319,6 +324,7 @@ export default function UserPostEditor() {
       formData.append('excerpt', normalizeExcerpt(manualExcerpt));
       formData.append('meta_title', metaTitle || '');
       formData.append('meta_description', metaDescription || '');
+      formData.append('seo_keywords', seoKeywords || '');
       formData.append('reading_time', String(stats.readingTime));
       formData.append('is_published', 'true');
 
@@ -341,7 +347,7 @@ export default function UserPostEditor() {
     }
   }, [
     editorData, extractedTitle,
-    manualExcerpt, metaTitle, metaDescription, stats.readingTime,
+    manualExcerpt, metaTitle, metaDescription, seoKeywords, stats.readingTime,
     publishCategoryId, publishTags, publishFeaturedFile, navigate
   ]);
 
@@ -433,6 +439,7 @@ export default function UserPostEditor() {
     selectedTags,
     metaTitle,
     metaDescription,
+    seoKeywords,
     customReadingTime,
     handleAutoSave,
   ]);
@@ -495,10 +502,12 @@ export default function UserPostEditor() {
         onTagToggle={handleTagToggle}
         metaTitle={metaTitle}
         metaDescription={metaDescription}
+        seoKeywords={seoKeywords}
         readingTime={stats.readingTime}
         onMetaChange={(updates) => {
           if (updates.metaTitle !== undefined) setMetaTitle(updates.metaTitle);
           if (updates.metaDescription !== undefined) setMetaDescription(updates.metaDescription);
+          if (updates.seoKeywords !== undefined) setSeoKeywords(updates.seoKeywords);
           if (updates.readingTime !== undefined) setCustomReadingTime(updates.readingTime);
           setIsDirty(true);
         }}

--- a/frontend/src/views/public/Blog/Detail.jsx
+++ b/frontend/src/views/public/Blog/Detail.jsx
@@ -351,6 +351,12 @@ export default function BlogDetail() {
     );
   }
 
+  const publishedAtMs = post.published_at ? new Date(post.published_at).getTime() : null;
+  const updatedAtMs = post.updated_at ? new Date(post.updated_at).getTime() : null;
+  const showUpdatedAt = Boolean(
+    updatedAtMs && (!publishedAtMs || updatedAtMs - publishedAtMs > 60_000)
+  );
+
   return (
     <Box>
       {/* Article Content */}
@@ -368,7 +374,15 @@ export default function BlogDetail() {
                 <Stack direction="row" alignItems="center" spacing={0.5}>
                   <IconCalendar size={16} color="#14213D" />
                   <Typography variant="body2" color="text.secondary">
-                    {formatDate(post.published_at)}
+                    Published {formatDate(post.published_at)}
+                  </Typography>
+                </Stack>
+              )}
+              {showUpdatedAt && (
+                <Stack direction="row" alignItems="center" spacing={0.5}>
+                  <IconCalendar size={16} color="#14213D" />
+                  <Typography variant="body2" color="text.secondary">
+                    Updated {formatDate(post.updated_at)}
                   </Typography>
                 </Stack>
               )}

--- a/frontend/src/views/public/Category/index.jsx
+++ b/frontend/src/views/public/Category/index.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { useParams, Link as RouterLink } from 'react-router-dom';
+import { useNavigate, useParams, Link as RouterLink } from 'react-router-dom';
 import {
   Box,
   Container,
@@ -27,6 +27,7 @@ const MotionBox = motion.create(Box);
  * - Subcategory: Shows posts directly with parent breadcrumb
  */
 export default function Category() {
+  const navigate = useNavigate();
   const { slug } = useParams();
   const [page, setPage] = useState(1);
   const postsPerPage = 6;
@@ -57,6 +58,10 @@ export default function Category() {
         setCategoryLoading(true);
         setCategoryError(null);
         const data = await getCategoryBySlug(slug);
+        if (data?.redirect_required && data?.canonical_slug && data.canonical_slug !== slug) {
+          navigate(`/category/${data.canonical_slug}`, { replace: true });
+          return;
+        }
         setCategory(data);
         setSelectedSubcategory('all'); // Reset filter
       } catch (err) {
@@ -70,7 +75,7 @@ export default function Category() {
 
     fetchCategory();
     setPage(1);
-  }, [slug]);
+  }, [slug, navigate]);
 
   // Get category IDs to query
   const categoryIdsToQuery = useMemo(() => {

--- a/frontend/tests/blogGenerationPayload.test.mjs
+++ b/frontend/tests/blogGenerationPayload.test.mjs
@@ -28,3 +28,10 @@ test('buildBlogGenerationPayload defaults web search to on', () => {
     true,
   );
 });
+
+test('buildBlogGenerationPayload defaults blog type to news', () => {
+  assert.equal(
+    buildBlogGenerationPayload({ topic: 'Default blog type' }).blog_type,
+    'news',
+  );
+});


### PR DESCRIPTION
## What changed

This PR adds the local foundation for the taxonomy and metadata rollout:

- adds taxonomy lifecycle support for canonical/deprecated tags
- adds slug history support for safer future slug changes
- adds `seo_keywords` persistence on posts
- adds new taxonomy migrations, including the approved subcategory rename phase and the first canonical tag migration batch
- adds DB-backed AI taxonomy and SEO keyword suggestions
- defaults AI blog generation to `News Article` with web search enabled
- preserves original `published_at` and exposes updated-date behavior for later edits
- adds Playwright coverage for the AI taxonomy flow, category slug redirect checks, and guarded production smoke scaffolding
- updates the OpenRouter model registry to newer GPT/GLM entries and adds Qwen 3.6 Plus

## Why it changed

We want taxonomy cleanup to happen before full automation so the AI generator can assign cleaner categories, tags, and SEO keywords from the database without introducing taxonomy drift. This also prepares the app for safe future slug normalization and gives us end-to-end test coverage before any VPS rollout.

## User and developer impact

- editors can now receive and persist AI-generated SEO keywords and taxonomy suggestions
- deprecated tags can be resolved safely to canonical tags instead of breaking saves
- category lookups are prepared for legacy-slug support
- publish/update timestamps now support showing both `Published` and `Updated`
- local E2E coverage now exists for the core generation flow

## Validation

- `api/venv/bin/pytest api/tests/test_ai_taxonomy.py api/tests/test_post_taxonomy_metadata.py api/tests/test_ai_router.py api/tests/test_posts_publish_flag.py -q`
- `api/venv/bin/pytest api/tests/test_ai_router.py -q`
- `api/venv/bin/python -m py_compile api/services/ai/llm_config.py api/schemas/ai.py api/scripts/benchmark_blog_generation.py`
- `npm --prefix frontend run test:node`
- `npm --prefix frontend run build`
- `npm --prefix frontend run test:e2e`

## Notes

- this PR does not change VPS or production
- two unrelated local edits were intentionally left out of this branch commit: `frontend/src/api/services/postService.js` and `frontend/src/views/dashboard/Posts/index.jsx`
- production rollout should happen only after this branch is reviewed and merged, then deployed in phases